### PR TITLE
feat(client, cli, ui): add glasskube serve command

### DIFF
--- a/cmd/glasskube/cmd/serve.go
+++ b/cmd/glasskube/cmd/serve.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/glasskube/glasskube/internal/web"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+var serveCmd = &cobra.Command{
+	Use:     "serve",
+	Aliases: []string{"start", "ui"},
+	Short:   "Open UI",
+	Long:    `Start server and open the UI.`,
+	Args:    cobra.ExactArgs(0),
+	Run: func(cmd *cobra.Command, args []string) {
+		err := web.Start()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "An error occurred starting the webserver:\n\n%v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(serveCmd)
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1,0 +1,44 @@
+package web
+
+import (
+	"fmt"
+	"net/http"
+	"os/exec"
+	"runtime"
+)
+
+var Host = "localhost"
+var Port = 8580
+
+func Start() error {
+	bindAddr := fmt.Sprintf("%v:%d", Host, Port)
+	url := fmt.Sprintf("http://%v", bindAddr)
+	fmt.Printf("glasskube UI is available at %v\n", url)
+	_ = openInBrowser(url)
+
+	http.HandleFunc("/", index)
+	err := http.ListenAndServe(bindAddr, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func index(w http.ResponseWriter, _ *http.Request) {
+	_, _ = fmt.Fprintf(w, "Hello World from Glasskube")
+}
+
+func openInBrowser(url string) error {
+	var err error
+	switch runtime.GOOS {
+	case "linux":
+		err = exec.Command("xdg-open", url).Start()
+	case "windows":
+		err = exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
+	case "darwin":
+		err = exec.Command("open", url).Start()
+	default:
+		err = fmt.Errorf("unsupported platform")
+	}
+	return err
+}


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #25 <!-- Issue # here -->

## 📑 Description
Introducing the `glasskube serve` command, which opens a browser tab on localhost:8580 and shows a hello world message.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->