### PR TITLE
feat(cli): add helpful message if kubeconfig is empty (#31)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ bin/
 dist/
 
 .idea/
+.vscode/

--- a/cmd/glasskube/cmd/install.go
+++ b/cmd/glasskube/cmd/install.go
@@ -2,8 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
-	"github.com/glasskube/glasskube/cmd/glasskube/config"
+	"github.com/glasskube/glasskube/internal/cliutils"
 	"github.com/glasskube/glasskube/pkg/client"
 	"github.com/glasskube/glasskube/pkg/condition"
 	"github.com/glasskube/glasskube/pkg/install"
@@ -11,18 +12,17 @@ import (
 )
 
 var installCmd = &cobra.Command{
-	Use:   "install [package-name]",
-	Short: "Install a package",
-	Long:  `Install a package.`,
-	Args:  cobra.ExactArgs(1),
+	Use:    "install [package-name]",
+	Short:  "Install a package",
+	Long:   `Install a package.`,
+	Args:   cobra.ExactArgs(1),
+	PreRun: cliutils.SetupClientContext,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		pkgClient, err := client.InitKubeClient(config.Kubeconfig)
+		client := client.FromContext(cmd.Context())
+		status, err := install.Install(client, cmd.Context(), args[0])
 		if err != nil {
-			return err
-		}
-		status, err := install.Install(pkgClient, cmd.Context(), args[0])
-		if err != nil {
-			return err
+			fmt.Fprintf(os.Stderr, "An error occurred during installation:\n\n%v\n", err)
+			os.Exit(1)
 		}
 		if status != nil {
 			switch (*status).Status {
@@ -33,7 +33,8 @@ var installCmd = &cobra.Command{
 					(*status).Status, (*status).Reason, (*status).Message)
 			}
 		} else {
-			fmt.Println("Installation status unknown - no error and no status have been observed.")
+			fmt.Fprintln(os.Stderr, "Installation status unknown - no error and no status have been observed (this is a bug).")
+			os.Exit(1)
 		}
 		return nil
 	},

--- a/cmd/glasskube/cmd/root.go
+++ b/cmd/glasskube/cmd/root.go
@@ -1,7 +1,10 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/glasskube/glasskube/cmd/glasskube/config"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/spf13/cobra"
 )
@@ -16,5 +19,5 @@ var (
 
 func init() {
 	RootCmd.PersistentFlags().StringVar(&config.Kubeconfig, "kubeconfig", "",
-		"path to the kubeconfig file, whose current-context will be used (defaults to ~/.kube/config)")
+		fmt.Sprintf("path to the kubeconfig file, whose current-context will be used (defaults to %v)", clientcmd.RecommendedHomeFile))
 }

--- a/internal/cliutils/setupclientcontext.go
+++ b/internal/cliutils/setupclientcontext.go
@@ -1,0 +1,35 @@
+package cliutils
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/glasskube/glasskube/cmd/glasskube/config"
+	"github.com/glasskube/glasskube/pkg/client"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+var (
+	helpEmptyConfig = fmt.Sprintf(`
+Your kubeconfig file is either empty or missing!
+Please, download the kubeconfig file from your cloud provider and copy it to the default location, or use the --kubeconfig flag.
+The default location is: %v
+
+If you want to test glasskube locally, check out minikube: https://minikube.sigs.k8s.io/
+	`, clientcmd.RecommendedHomeFile)
+)
+
+func SetupClientContext(cmd *cobra.Command, args []string) {
+	ctx, err := client.SetupContext(cmd.Context(), config.Kubeconfig)
+	if err != nil {
+		if clientcmd.IsEmptyConfig(err) {
+			fmt.Fprintln(os.Stderr, helpEmptyConfig)
+		} else {
+			fmt.Fprintf(os.Stderr, "Your kubeconfig file is invalid:\n\n%v\n", err)
+		}
+		os.Exit(1)
+	} else {
+		cmd.SetContext(ctx)
+	}
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,20 +1,31 @@
 package client
 
 import (
+	"context"
+
 	"github.com/glasskube/glasskube/api/v1alpha1"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	clientContextKey = iota
 )
 
 var PackageGVR = v1alpha1.GroupVersion.WithResource("packages")
 
-func InitKubeClient(kubeconfig string) (*PackageV1Alpha1Client, error) {
+func InitKubeConfig(kubeconfig string) (*rest.Config, error) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	if kubeconfig != "" {
 		loadingRules.ExplicitPath = kubeconfig
 	}
 	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{})
-	config, err := clientConfig.ClientConfig()
+	return clientConfig.ClientConfig()
+}
+
+func SetupContext(ctx context.Context, kubeconfig string) (context.Context, error) {
+	config, err := InitKubeConfig(kubeconfig)
 	if err != nil {
 		return nil, err
 	}
@@ -26,5 +37,15 @@ func InitKubeClient(kubeconfig string) (*PackageV1Alpha1Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	return pkgClient, nil
+	return context.WithValue(ctx, clientContextKey, pkgClient), nil
+}
+
+func FromContext(ctx context.Context) *PackageV1Alpha1Client {
+	value := ctx.Value(clientContextKey)
+	if value != nil {
+		if client, ok := value.(*PackageV1Alpha1Client); ok {
+			return client
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Actually doesn't resolve any issues, because #31 is for the web UI as well

## 📑 Description
We now show a different error message  depending on whether the kubeconfig is empty or missing, or another error occurred (e.g. kubeconfig malformed).

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
I changed the install command so that the PackageClient is stored in the cmd.Context(). This way, the CLI-specific initialization code can be reused for future commands that require the same validation.