### PR TITLE
fix(helm-flux-adapter): avoid panic when helm values are empty

### DIFF
--- a/internal/manifest/helm/flux/adapter.go
+++ b/internal/manifest/helm/flux/adapter.go
@@ -114,7 +114,11 @@ func ensureHelmRelease(ctx context.Context, client client.Client, pkg *packagesv
 		helmRelease.Spec.Chart.Spec.Version = manifest.Helm.ChartVersion
 		helmRelease.Spec.Chart.Spec.SourceRef.Kind = "HelmRepository"
 		helmRelease.Spec.Chart.Spec.SourceRef.Name = manifest.Name
-		helmRelease.Spec.Values = &apiextensionsv1.JSON{Raw: manifest.Helm.Values.Raw[:]}
+		if manifest.Helm.Values != nil {
+			helmRelease.Spec.Values = &apiextensionsv1.JSON{Raw: manifest.Helm.Values.Raw[:]}
+		} else {
+			helmRelease.Spec.Values = nil
+		}
 		helmRelease.Spec.Interval = metav1.Duration{Duration: 5 * time.Minute}
 		return controllerutil.SetOwnerReference(pkg, &helmRelease, client.Scheme())
 	})


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->


## 📑 Description
helm.values are optional in the package manifest, e.g. the ingress-nginx does not have any: https://github.com/glasskube/packages/blob/main/packages/ingress-nginx/package.yaml

The Flux Helm Adapter didn't check for whether is empty and therefore paniced on reconciliation. 

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->