### PR TITLE
feat(cli): add completion for install cmd

### DIFF
--- a/cmd/glasskube/cmd/install.go
+++ b/cmd/glasskube/cmd/install.go
@@ -3,8 +3,10 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/glasskube/glasskube/internal/cliutils"
+	"github.com/glasskube/glasskube/internal/repo"
 	"github.com/glasskube/glasskube/pkg/client"
 	"github.com/glasskube/glasskube/pkg/condition"
 	"github.com/glasskube/glasskube/pkg/install"
@@ -12,12 +14,13 @@ import (
 )
 
 var installCmd = &cobra.Command{
-	Use:    "install [package-name]",
-	Short:  "Install a package",
-	Long:   `Install a package.`,
-	Args:   cobra.ExactArgs(1),
-	PreRun: cliutils.SetupClientContext,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	Use:               "install [package-name]",
+	Short:             "Install a package",
+	Long:              `Install a package.`,
+	Args:              cobra.ExactArgs(1),
+	PreRun:            cliutils.SetupClientContext,
+	ValidArgsFunction: completeAvailablePackageNames,
+	Run: func(cmd *cobra.Command, args []string) {
 		client := client.FromContext(cmd.Context())
 		status, err := install.Install(client, cmd.Context(), args[0])
 		if err != nil {
@@ -36,8 +39,24 @@ var installCmd = &cobra.Command{
 			fmt.Fprintln(os.Stderr, "Installation status unknown - no error and no status have been observed (this is a bug).")
 			os.Exit(1)
 		}
-		return nil
 	},
+}
+
+func completeAvailablePackageNames(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return []string{}, cobra.ShellCompDirectiveNoFileComp
+	}
+	index, err := repo.FetchPackageRepoIndex(cmd.Context(), "")
+	if err != nil {
+		return []string{}, cobra.ShellCompDirectiveError
+	}
+	names := make([]string, 0, len(index.Packages))
+	for _, pkg := range index.Packages {
+		if toComplete == "" || strings.HasPrefix(pkg.Name, toComplete) {
+			names = append(names, pkg.Name)
+		}
+	}
+	return names, 0
 }
 
 func init() {


### PR DESCRIPTION
## 📑 Description
This PR adds autocompletion for the `glasskube install` command

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
To install autocompletion check out `glasskube help completion [your shell]`
(e.g. `glasskube help completion bash`)