### PR TITLE
ci: rename homebrew tap repository and install docs

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -78,7 +78,7 @@ brews:
     license: "Apache-2.0"
     repository:
       owner: glasskube
-      name: homebrew-glasskube
+      name: homebrew-tap
     url_template: "https://releases.dl.glasskube.dev/{{ .ArtifactName }}"
     commit_author:
       name: glasskube-bot

--- a/README.md
+++ b/README.md
@@ -76,8 +76,7 @@ Designed as a cloud native application, so you can follow your **GitOps approach
 Install Glasskube via [Homebrew](https://brew.sh/):
 
 ```bash
-brew tap glasskube/glasskube
-brew install glasskube
+brew install glasskube/tap/glasskube
 ```
 
 Start the package manager:

--- a/website/docs/04_guides/01_cert-manager.mdx
+++ b/website/docs/04_guides/01_cert-manager.mdx
@@ -68,8 +68,7 @@ If not, `glasskube` can easily be installed the way you usually install packages
 <Tabs groupId="operating-systems">
   <TabItem value="mac" label="macOS">
     ```shell
-    brew tap glasskube/glasskube
-    brew install glasskube
+    brew install glasskube/tap/glasskube
     ```
   </TabItem>
   <TabItem value="linux" label="Linux">

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -29,8 +29,7 @@ Install your first package in 5 minutes.
 Install Glasskube via [Homebrew](https://brew.sh/):
 
 ```bash
-brew tap glasskube/glasskube
-brew install glasskube
+brew install glasskube/tap/glasskube
 ```
 
 Start the package manager:

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -45,10 +45,7 @@ function HomepageHeader() {
                     typewriter
                       .changeDeleteSpeed(25)
                       .changeDelay(75)
-                      .typeString('brew tap <span class="typewriter-command">glasskube/glasskube</span>')
-                      .pauseFor(1500)
-                      .deleteAll(25)
-                      .typeString('brew install <span class="typewriter-command">glasskube</span>')
+                      .typeString('brew install <span class="typewriter-command">glasskube/tap/glasskube</span>')
                       .pauseFor(1500)
                       .deleteAll(25)
                       .typeString('glasskube install ')


### PR DESCRIPTION
## 📑 Description

For this change the repo github.com/glasskube/homebrew-glasskube was renamed to  github.com/glasskube/homebrew-tap

## ✅ Checks
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required

