### PR TITLE
docs: change asciinema link to gif

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ In the next versions you will be able to install more packages like the [Kube-Pr
 
 ## 🎬 How to install you first package
 
-[![asciicast](https://asciinema.org/a/k19wlsoX5Mr3raY6ro13imyNo.svg)](https://asciinema.org/a/k19wlsoX5Mr3raY6ro13imyNo)
+![634355](https://github.com/glasskube/glasskube/assets/16959694/967b9657-c416-4078-89ad-774aa0f01429)
 
 ## Architecture Diagram
 ```mermaid


### PR DESCRIPTION
## 📑 Description
This PR replaces the Asciinema link in our readme with an embedded GIF. 

Preview: https://github.com/glasskube/glasskube/blob/kosmoz/readme-gif/README.md

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information

Note, that there is currently no direct way to use asciinema recordings as GIFs or videos. 
There is only a [tool that does the conversion locally](https://github.com/asciinema/agg), but it has it's limitations, like not supporting all characters.

I think the Asciinema preview looks better. I also tried converting the GIF to a video but that looked truly terrible.