### PR TITLE
fix(package-operator): remove cluster.local dns suffix from flux manifests

### DIFF
--- a/config/dependencies/flux/helm-controller.yaml
+++ b/config/dependencies/flux/helm-controller.yaml
@@ -2286,7 +2286,7 @@ spec:
     spec:
       containers:
       - args:
-        - --events-addr=http://notification-controller.flux-system.svc.cluster.local./
+        - --events-addr=http://notification-controller/
         - --watch-all-namespaces
         - --log-level=info
         - --log-encoding=json

--- a/config/dependencies/flux/source-controller.yaml
+++ b/config/dependencies/flux/source-controller.yaml
@@ -3296,13 +3296,13 @@ spec:
     spec:
       containers:
       - args:
-        - --events-addr=http://notification-controller.flux-system.svc.cluster.local./
+        - --events-addr=http://notification-controller/
         - --watch-all-namespaces
         - --log-level=info
         - --log-encoding=json
         - --enable-leader-election
         - --storage-path=/data
-        - --storage-adv-addr=source-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
+        - --storage-adv-addr=source-controller
         env:
         - name: RUNTIME_NAMESPACE
           valueFrom:


### PR DESCRIPTION
Closes #148 

## 📑 Description
This PR removes the …cluster.local part from the domains in flux manifests, so it should also work on clusters where this name is different.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information