### PR TITLE
docs: change release-please annotations to mdx comments

### DIFF
--- a/website/src/partials/_install.mdx
+++ b/website/src/partials/_install.mdx
@@ -13,32 +13,32 @@ import TabItem from '@theme/TabItem';
     <details>
       <summary>RPM-based installation (RedHat/CentOS/Fedora)</summary>
 
-      <!---x-release-please-start-version-->
+      {/* x-release-please-start-version */}
       ```
       dnf install https://github.com/glasskube/glasskube/releases/download/v0.0.1/glasskube_v0.0.1_amd64.rpm
       ```
-      <!---x-release-please-end-->
+      {/* x-release-please-end */}
     </details>
 
     <details>
       <summary>DEB-based installation (Ubuntu/Debian)</summary>
 
-      <!---x-release-please-start-version-->
+      {/* x-release-please-start-version */}
       ```
       curl -LO https://github.com/glasskube/glasskube/releases/download/v0.0.1/glasskube_v0.0.1_amd64.deb
       sudo dpkg -i glasskube.deb
       ```
-      <!---x-release-please-end-->
+      {/* x-release-please-end */}
     </details>
 
     <details>
       <summary>APK-based installation (Alpine)</summary>
-      <!---x-release-please-start-version-->
+      {/* x-release-please-start-version */}
       ```
       curl -LO https://github.com/glasskube/glasskube/releases/download/v0.0.1/glasskube_v0.0.1_amd64.apk
       apk add glasskube.apk
       ```
-      <!---x-release-please-end-->
+      {/* x-release-please-end */}
     </details>
 
     If you are using a distribution that does not use one of the package managers above, or require a 32-bit binary,
@@ -46,10 +46,10 @@ import TabItem from '@theme/TabItem';
   </TabItem>
 
   <TabItem value="win" label="Windows">
-    <!---x-release-please-start-version-->
+    {/* x-release-please-start-version */}
     Download the [windows archive](https://github.com/glasskube/glasskube/releases/download/v0.0.1/glasskube_v0.0.1_windows_x86_64.zip) from our
     latest [Release](https://github.com/glasskube/glasskube/releases/latest) and unpack it using Windows Explorer.
-    <!---x-release-please-end-->
+    {/* x-release-please-end */}
   </TabItem>
 </Tabs>
 


### PR DESCRIPTION
## 📑 Description
This should improve compatibility with different renderers, as HTML comments are not always supported.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
After merging, we need to monitor if release-please still picks these up, but I think it should.
The relevant documentation can be found [here](https://github.com/googleapis/release-please/blob/main/docs/customizing.md#updating-arbitrary-files).