### PR TITLE
feat: add `port` flag to `glasskube serve`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,3 +69,55 @@ The following `<type>`s are available:
 
 This format is based on [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
 Please refer to the Conventional Commits specification for more details.
+
+## Development Guide
+
+Glasskube is developed using the [Go](https://golang.org/) programming language. The current version of Go being used is [v1.21](https://go.dev/doc/go1.21). It uses go modules for dependency management.
+
+### Building
+
+Once you've made your changes, you might want to build a binary of the glasskube CLI containing your changes to test them out. This can be done by running the following command at the root of the project:
+
+```
+make
+```
+
+This will create the `glasskube` and `package-operator` binary in the `dist` folder. You can execute the binary by running the following:
+
+```
+dist/glasskube
+```
+
+After you make more changes, simply run `make` again to recompile your changes.
+
+### Executing
+
+In order to execute the `glasskube` binary locally, you can do this manually by creating a copy of it to your project directory.
+
+However, there's an easy and preferred way for doing this by creating an `alias` using the following command:
+
+```
+alias <alias-name> = /path/to/glasskube/binary
+```
+
+This will make sure the `alias-name` is in sync with your glasskube binary. However, this is a temporary alias. If you'd like to create a permanent alias, you can read more about it [here](https://www.freecodecamp.org/news/how-to-create-your-own-command-in-linux/).
+
+**Note:** Don't use `alias-name` as _glasskube_ since the actual glasskube CLI tool installed locally will get in conflict with executable `glasskube` binary.
+
+### Testing
+
+Unit tests for the project can be executed by running:
+
+```
+make test
+```
+
+This command will run all the unit tests, will try to detect race conditions, and will generate a test coverage report.
+
+### Linting
+
+Before making a PR, we recommend contributors to run a lint check on their code by running:
+
+```
+make lint
+```

--- a/cmd/glasskube/cmd/serve.go
+++ b/cmd/glasskube/cmd/serve.go
@@ -53,6 +53,13 @@ var serveCmd = &cobra.Command{
 			}
 		}
 
+		port, err := cmd.Flags().GetInt("port")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error fetching the port number")
+			os.Exit(1)
+		}
+		web.Port = port
+
 		err = web.Start(ctx, support)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "An error occurred starting the webserver:\n\n%v\n", err)
@@ -62,5 +69,6 @@ var serveCmd = &cobra.Command{
 }
 
 func init() {
+	serveCmd.Flags().IntP("port", "p", 8580, "Port for the webserver")
 	RootCmd.AddCommand(serveCmd)
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -52,7 +52,7 @@ func Start(ctx context.Context, support *ServerConfigSupport) error {
 		if support != nil {
 			err := supportTemplate.Execute(w, support)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "An error occured rendering the response: \n%v\n", err)
+				fmt.Fprintf(os.Stderr, "An error occurred rendering the response: \n%v\n", err)
 			}
 			return
 		}
@@ -68,7 +68,7 @@ func Start(ctx context.Context, support *ServerConfigSupport) error {
 			if pkg != nil {
 				err := uninstall.Uninstall(pkgClient, ctx, pkg)
 				if err != nil {
-					fmt.Fprintf(os.Stderr, "An error occured uninstalling %v: \n%v\n", pkgName, err)
+					fmt.Fprintf(os.Stderr, "An error occurred uninstalling %v: \n%v\n", pkgName, err)
 				}
 				http.Redirect(w, r, "/", http.StatusFound)
 			} else {


### PR DESCRIPTION
Closes #83
## 📑 Description
- `glasskube serve` generally listens on port `8580`. This PR ensures to add a new flag `--port` to the `glassdoor serve` command so that the webserver can be opened on any port specified via CLI Flag.

![image](https://github.com/glasskube/glasskube/assets/86051118/0d71b5f5-cfe1-4195-9fe5-8cbd01d07a61)

## ✅ Checks
- [x] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information

- Updated the `contributing.md` file to mention developing the glasskube binary locally. 
- Fix minor typos in the codebase.