### PR TITLE
ci: fix build workflow not run on PRs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,9 @@ on:
   push:
     paths-ignore:
       - website/**
+  pull_request:
+    paths-ignore:
+      - website/**
 
 jobs:
   cli:


### PR DESCRIPTION
## 📑 Description
The build workflow does not run for PRs from forks. This PR fixes that.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->