### PR TITLE
ci: disable commit lint default ignores

### DIFF
--- a/.github/workflows/commit-lint.yaml
+++ b/.github/workflows/commit-lint.yaml
@@ -20,7 +20,8 @@ jobs:
             extends: ['@commitlint/config-conventional'],
             rules: {
               'body-max-line-length': [2, 'always', 1000]
-            }
+            },
+            defaultIgnores: false
           }" > commitlint.config.js
       - name: Validate PR commits with commitlint
         run: |


### PR DESCRIPTION
## 📑 Description

commit lint has a default ignore list:
https://github.com/conventional-changelog/commitlint/blob/master/%40commitlint/is-ignored/src/defaults.ts

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

