### PR TITLE
build: prevent uploading prereleases to brew tap

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -85,6 +85,7 @@ brews:
     commit_msg_template: "chore: brew formula update for {{ .ProjectName }} version {{ .Tag }}"
     install: |
       bin.install "glasskube"
+    skip_upload: "auto"
 
 release:
   prerelease: auto


### PR DESCRIPTION
## 📑 Description
We should not publish prereleases in this way.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->