### PR TITLE
docs: use a custom domain for binary downloads

### DIFF
--- a/website/src/partials/_install.mdx
+++ b/website/src/partials/_install.mdx
@@ -15,7 +15,7 @@ import TabItem from '@theme/TabItem';
 
       {/* x-release-please-start-version */}
       ```
-      dnf install https://github.com/glasskube/glasskube/releases/download/v0.0.1/glasskube_v0.0.1_amd64.rpm
+      dnf install https://releases.dl.glasskube.dev/glasskube_v0.0.1_amd64.rpm
       ```
       {/* x-release-please-end */}
     </details>
@@ -25,7 +25,7 @@ import TabItem from '@theme/TabItem';
 
       {/* x-release-please-start-version */}
       ```
-      curl -LO https://github.com/glasskube/glasskube/releases/download/v0.0.1/glasskube_v0.0.1_amd64.deb
+      curl -LO https://releases.dl.glasskube.dev/glasskube_v0.0.1_amd64.deb
       sudo dpkg -i glasskube_v0.0.1_amd64.deb
       ```
       {/* x-release-please-end */}
@@ -35,7 +35,7 @@ import TabItem from '@theme/TabItem';
       <summary>APK-based installation (Alpine)</summary>
       {/* x-release-please-start-version */}
       ```
-      curl -LO https://github.com/glasskube/glasskube/releases/download/v0.0.1/glasskube_v0.0.1_amd64.apk
+      curl -LO https://releases.dl.glasskube.dev/glasskube_v0.0.1_amd64.apk
       apk add glasskube.apk
       ```
       {/* x-release-please-end */}
@@ -47,7 +47,7 @@ import TabItem from '@theme/TabItem';
 
   <TabItem value="win" label="Windows">
     {/* x-release-please-start-version */}
-    Download the [windows archive](https://github.com/glasskube/glasskube/releases/download/v0.0.1/glasskube_v0.0.1_windows_x86_64.zip) from our
+    Download the [windows archive](https://releases.dl.glasskube.dev/glasskube_v0.0.1_windows_x86_64.zip) from our
     latest [Release](https://github.com/glasskube/glasskube/releases/latest) and unpack it using Windows Explorer.
     {/* x-release-please-end */}
   </TabItem>


### PR DESCRIPTION
## 📑 Description
Executables will still be downloaded from GitHub release assets This commit should also solve the release-please problem of having multiple version replacements in one line (googleapis/release-please#2137).
