### PR TITLE
build: change deprecated goreleaser config property

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -111,4 +111,4 @@ archives:
     allow_different_binary_count: true
 
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
## 📑 Description
`changelog.skip` is deprecated, this showed up in the logs of our release workflow.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
Ref: https://goreleaser.com/deprecations/#changelogskip