### PR TITLE
fix(action): build package-operator image for amd64, arm64

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,6 +47,10 @@ jobs:
           registry: ghcr.io
           username: glasskube-bot
           password: ${{ secrets.GLASSKUBE_BOT_SECRET }}
+      - name: Setup qemu
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: amd64,arm64
       - name: Set up Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,13 +33,14 @@ builds:
     binary: package-operator
 
 dockers:
-  - use: docker
+  - image_templates:
+      - "ghcr.io/glasskube/package-operator:{{.Tag}}-amd64"
+      - "ghcr.io/glasskube/package-operator:latest-amd64"
+    use: buildx
     dockerfile: release.Dockerfile
-    image_templates:
-      - "ghcr.io/glasskube/package-operator:{{.Tag}}"
-      - "ghcr.io/glasskube/package-operator:latest"
     build_flag_templates:
       - "--pull"
+      - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
@@ -49,6 +50,34 @@ dockers:
       - "--label=org.opencontainers.image.source=https://github.com/glasskube/glasskube/"
       - "--label=org.opencontainers.image.url=https://glasskube.dev/"
       - "--label=org.opencontainers.image.documentation=https://glasskube.dev/docs/"
+  - image_templates:
+      - "ghcr.io/glasskube/package-operator:{{.Tag}}-arm64"
+      - "ghcr.io/glasskube/package-operator:latest-arm64"
+    use: buildx
+    dockerfile: release.Dockerfile
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - '--label=org.opencontainers.image.title="Glasskube package-operator"'
+      - "--label=org.opencontainers.image.vendor=Glasskube"
+      - "--label=org.opencontainers.image.licenses=Apache-2.0"
+      - "--label=org.opencontainers.image.source=https://github.com/glasskube/glasskube/"
+      - "--label=org.opencontainers.image.url=https://glasskube.dev/"
+      - "--label=org.opencontainers.image.documentation=https://glasskube.dev/docs/"
+    goarch: arm64
+
+docker_manifests:
+  - name_template: "ghcr.io/glasskube/package-operator:{{.Tag}}"
+    image_templates:
+      - "ghcr.io/glasskube/package-operator:{{.Tag}}-amd64"
+      - "ghcr.io/glasskube/package-operator:{{.Tag}}-arm64"
+  - name_template: "ghcr.io/glasskube/package-operator:latest"
+    image_templates:
+      - "ghcr.io/glasskube/package-operator:latest-amd64"
+      - "ghcr.io/glasskube/package-operator:latest-arm64"
 
 nfpms:
   - file_name_template: "{{ .ProjectName }}_{{ .Tag }}_{{ .Arch }}"


### PR DESCRIPTION

Closes #237 

## 📑 Description

I adjusted the goreleaser configuration as well as the action definitions to build multiarch images, at the moment for `linux/amd64` and `linux/arm64`.

The resulting image runs on Apple Silicon architectures, I double-checked.

## Further Remarks

If you want to see the updated action in action (pun intended), [have a look at my fork](https://github.com/mocdaniel/glasskube/actions/runs/7857834325/job/21442133990), and/or pull the resulting images from [here](https://github.com/users/mocdaniel/packages/container/package/package-operator).