### PR TITLE
feat: add Scheme, LocalPort to PackageEntrypoint

### DIFF
--- a/api/v1alpha1/package_manifest.go
+++ b/api/v1alpha1/package_manifest.go
@@ -40,6 +40,9 @@ type PackageEntrypoint struct {
 	ServiceName string `json:"serviceName" jsonschema:"required"`
 	// Port of the service to bind to
 	Port int32 `json:"port" jsonschema:"required"`
+	// LocalPort to use for port mapping
+	LocalPort int32  `json:"localPort,omitempty"`
+	Scheme    string `json:"scheme,omitempty"`
 }
 
 type PlainManifest struct {

--- a/config/crd/bases/packages.glasskube.dev_packageinfos.yaml
+++ b/config/crd/bases/packages.glasskube.dev_packageinfos.yaml
@@ -125,6 +125,10 @@ spec:
                       description: PackageEntrypoint defines a service port a user
                         may use to access the package
                       properties:
+                        localPort:
+                          description: LocalPort to use for port mapping
+                          format: int32
+                          type: integer
                         name:
                           description: Name of this entrypoint. Used for "glasskube
                             open [package-name] [entrypoint-name]" if more than one
@@ -135,6 +139,8 @@ spec:
                           description: Port of the service to bind to
                           format: int32
                           type: integer
+                        scheme:
+                          type: string
                         serviceName:
                           description: ServiceName is the name of a service that is
                             part of

--- a/schema/package-manifest/schema.json
+++ b/schema/package-manifest/schema.json
@@ -45,6 +45,12 @@
         },
         "port": {
           "type": "integer"
+        },
+        "localPort": {
+          "type": "integer"
+        },
+        "scheme": {
+          "type": "string"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
## 📑 Description

This PR adds two optional properties to the PackageEntrypoint type: `Scheme` and `LocalPort`.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
This is needed to fix the entrypoint for the kubernetes-dashboard.

Once this PR has been approved and merged, the kubernetes-dashboard package must be updated to use the new properties.