### PR TITLE
chore: change schema to not use $ref and move to website

### DIFF
--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -5,12 +5,12 @@ on:
     branches:
       - main
     paths:
-      - schema/**
+      - website/static/schemas/**
   pull_request:
     branches:
       - main
     paths:
-      - schema/**
+      - website/static/schemas/**
 
 jobs:
   validate:
@@ -21,4 +21,4 @@ jobs:
         uses: cardinalby/schema-validator-action@v3
         with:
           file: "test/package-manifest/example.yaml"
-          schema: "./schema/package-manifest/schema.json"
+          schema: "./website/static/schemas/v1/package-manifest.json"

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ help: ## Display this help.
 
 .PHONY: schema-gen
 schema-gen: # Generate a schema.json file for the package manifest type.
-	go run ./internal/cmd/schema-gen -o schema
+	go run ./internal/cmd/schema-gen
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.

--- a/test/package-manifest/example.yaml
+++ b/test/package-manifest/example.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=../../schema/package-manifest/schema.json
+# yaml-language-server: $schema=../../website/static/schemas/v1/package-manifest.json
 name: example
 shortDescription: |
   1-2 sentences describing your package

--- a/website/static/schemas/v1/package-manifest.json
+++ b/website/static/schemas/v1/package-manifest.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/glasskube/glasskube/api/v1alpha1/package-manifest",
-  "$ref": "#/$defs/PackageManifest",
+  "$id": "https://glasskube.dev/schemas/v1/package-manifest.json",
   "$defs": {
     "HelmManifest": {
       "properties": {
@@ -60,56 +59,6 @@
         "port"
       ]
     },
-    "PackageManifest": {
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "shortDescription": {
-          "type": "string"
-        },
-        "longDescription": {
-          "type": "string"
-        },
-        "references": {
-          "items": {
-            "$ref": "#/$defs/PackageReference"
-          },
-          "type": "array"
-        },
-        "iconUrl": {
-          "type": "string",
-          "format": "uri"
-        },
-        "helm": {
-          "$ref": "#/$defs/HelmManifest"
-        },
-        "kustomize": {
-          "$ref": "#/$defs/KustomizeManifest"
-        },
-        "manifests": {
-          "items": {
-            "$ref": "#/$defs/PlainManifest"
-          },
-          "type": "array"
-        },
-        "defaultNamespace": {
-          "type": "string"
-        },
-        "entrypoints": {
-          "items": {
-            "$ref": "#/$defs/PackageEntrypoint"
-          },
-          "type": "array"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "name",
-        "defaultNamespace"
-      ]
-    },
     "PackageReference": {
       "properties": {
         "label": {
@@ -138,5 +87,53 @@
         "url"
       ]
     }
-  }
+  },
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "shortDescription": {
+      "type": "string"
+    },
+    "longDescription": {
+      "type": "string"
+    },
+    "references": {
+      "items": {
+        "$ref": "#/$defs/PackageReference"
+      },
+      "type": "array"
+    },
+    "iconUrl": {
+      "type": "string",
+      "format": "uri"
+    },
+    "helm": {
+      "$ref": "#/$defs/HelmManifest"
+    },
+    "kustomize": {
+      "$ref": "#/$defs/KustomizeManifest"
+    },
+    "manifests": {
+      "items": {
+        "$ref": "#/$defs/PlainManifest"
+      },
+      "type": "array"
+    },
+    "defaultNamespace": {
+      "type": "string"
+    },
+    "entrypoints": {
+      "items": {
+        "$ref": "#/$defs/PackageEntrypoint"
+      },
+      "type": "array"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "name",
+    "defaultNamespace"
+  ]
 }


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #258 <!-- Issue # here -->

## 📑 Description
With this PR, our schema files no longer use $ref, since it is strictly speaking not standards compliant and not very well supported by some tooling. 

The schema files are now written to website/static, which makes them available via our website. 

The $id of the schema reflects this change.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

Once this is merged, we can remove the schema files from the packages repo and update all packages to reference the new schema location