### PR TITLE
chore: make renovate run "go mod tidy"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "postUpdateOptions": [
+    "gomodTidy"
+  ],
   "extends": [
     "config:recommended"
   ]


### PR DESCRIPTION


## 📑 Description
Renovate does not do this by default.

Relevant documentation: https://docs.renovatebot.com/golang/#module-tidying

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->