### PR TITLE
feat: add version command

### DIFF
--- a/cmd/glasskube/cmd/version.go
+++ b/cmd/glasskube/cmd/version.go
@@ -35,7 +35,7 @@ func init() {
 }
 
 func getPackageOperatorVersion(ctx context.Context) (string, error) {
-	config := cliutils.RequireConfig("")
+	config, _ := cliutils.RequireConfig("")
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return "", err

--- a/cmd/glasskube/cmd/version.go
+++ b/cmd/glasskube/cmd/version.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/glasskube/glasskube/internal/config"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
+)
+
+var versioncmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version of glasskube and package-operator",
+	Long:  `Print the version of glasskube and package-operator`,
+	Run: func(cmd *cobra.Command, args []string) {
+		glasskubeVersion := config.Version
+		fmt.Fprintf(os.Stderr, "glasskube: v%s\n", glasskubeVersion)
+		operatorVersion, err := getPackageOperatorVersion()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "✗ no deployments found in the glasskube-system namespace\n")
+		} else {
+			fmt.Fprintf(os.Stderr, "package-operator: %s\n", operatorVersion)
+		}
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(versioncmd)
+}
+
+func getPackageOperatorVersion() (string, error) {
+	var kubeconfig string
+	if home := homedir.HomeDir(); home != "" {
+		flag.StringVar(&kubeconfig, "kubeconfig", home+"/.kube/config", "(optional) absolute path to the kubeconfig file")
+	} else {
+		flag.StringVar(&kubeconfig, "kubeconfig", "", "absolute path to the kubeconfig file")
+	}
+	flag.Parse()
+
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return "", err
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return "", err
+	}
+
+	namespace := "glasskube-system"
+	deploymentName := "glasskube-controller-manager"
+	deployment, err := clientset.AppsV1().Deployments(namespace).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	containers := deployment.Spec.Template.Spec.Containers
+	for _, container := range containers {
+		if container.Name == "manager" {
+			ref, err := name.ParseReference(container.Image)
+			if err != nil {
+				return "", err
+			}
+			parts := strings.Split(ref.Identifier(), ":")
+			return parts[0], nil
+		}
+	}
+	return "", nil
+}

--- a/cmd/glasskube/cmd/version.go
+++ b/cmd/glasskube/cmd/version.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/glasskube/glasskube/internal/cliutils"
 	"github.com/glasskube/glasskube/internal/config"
+	"github.com/glasskube/glasskube/pkg/client"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,7 +18,7 @@ var versioncmd = &cobra.Command{
 	Use:    "version",
 	Short:  "Print the version of glasskube and package-operator",
 	Long:   `Print the version of glasskube and package-operator`,
-	PreRun: cliutils.SetupClientContext(true),
+	PreRun: cliutils.SetupClientContext(false),
 	Run: func(cmd *cobra.Command, args []string) {
 		glasskubeVersion := config.Version
 		fmt.Fprintf(os.Stderr, "glasskube: v%s\n", glasskubeVersion)
@@ -35,7 +36,7 @@ func init() {
 }
 
 func getPackageOperatorVersion(ctx context.Context) (string, error) {
-	config, _ := cliutils.RequireConfig("")
+	config := client.ConfigFromContext(ctx)
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return "", err

--- a/cmd/glasskube/cmd/version.go
+++ b/cmd/glasskube/cmd/version.go
@@ -35,7 +35,8 @@ func init() {
 }
 
 func getPackageOperatorVersion(ctx context.Context) (string, error) {
-	clientset, err := kubernetes.NewForConfig(cliutils.RequireConfig(""))
+	config := cliutils.RequireConfig("")
+	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return "", err
 	}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/fatih/color v1.16.0
 	github.com/fluxcd/helm-controller/api v0.37.4
 	github.com/fluxcd/source-controller/api v1.2.4
+	github.com/google/go-containerregistry v0.19.0
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.1
 	github.com/invopop/jsonschema v0.12.0
@@ -64,6 +65,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.18.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-containerregistry v0.19.0 h1:uIsMRBV7m/HDkDxE/nXMnv1q+lOOSPlQ/ywc5JbB8Ic=
+github.com/google/go-containerregistry v0.19.0/go.mod h1:u0qB2l7mvtWVR5kNcbFIhFY1hLbf8eeGapA+vbFDCtQ=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -113,6 +115,8 @@ github.com/onsi/ginkgo/v2 v2.15.0 h1:79HwNRBAZHOEwrczrgSOPy+eFTTlIGELKy5as+ClttY
 github.com/onsi/ginkgo/v2 v2.15.0/go.mod h1:HlxMHtYF57y6Dpf+mc5529KKmSq9h2FpCF+/ZkwUxKM=
 github.com/onsi/gomega v1.31.1 h1:KYppCUK+bUgAZwHOu7EXVBKyQA6ILvOESHkn/tgoqvo=
 github.com/onsi/gomega v1.31.1/go.mod h1:y40C95dwAD1Nz36SsEnxvfFe8FFfNxzI5eJ0EYGyAy0=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #254 

## 📑 Description
Added a version command which prints the version of glasskube and package-operator.
```
$ glasskube version
glasskube: v0.0.3
package-operator: v0.0.2 
```
If no deployments are found under glasskube-system namespace it prints
```
$ glasskube version
glasskube: v0.0.3
✗ no deployments found in the glasskube-system namespace
```



## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->