### PR TITLE
feat: add blocking owner deletion 

### DIFF
--- a/cmd/package-operator/main.go
+++ b/cmd/package-operator/main.go
@@ -94,7 +94,7 @@ func main() {
 		Client:        mgr.GetClient(),
 		EventRecorder: mgr.GetEventRecorderFor("package-controller"),
 		Scheme:        mgr.GetScheme(),
-		Helm:          flux.NewAdapter(mgr.GetScheme()),
+		Helm:          flux.NewAdapter(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Package")
 		os.Exit(1)

--- a/internal/controller/owners/owners.go
+++ b/internal/controller/owners/owners.go
@@ -1,0 +1,85 @@
+package owners
+
+import (
+	"errors"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+type OwnerManager struct {
+	scheme *runtime.Scheme
+}
+
+type OwnerOptions int
+
+const (
+	BlockOwnerDeletion OwnerOptions = 1 << iota
+	Controller
+	DefaultOptions OwnerOptions = 0
+)
+
+var (
+	ErrNoSuchOwner = errors.New("no such owner")
+)
+
+func NewOwnerManager(scheme *runtime.Scheme) *OwnerManager {
+	return &OwnerManager{scheme: scheme}
+}
+
+func (mgr *OwnerManager) HasOwner(owner client.Object, obj metav1.Object) (bool, error) {
+	if _, err := mgr.findOwnerReferenceIndex(owner, obj.GetOwnerReferences()); err != nil {
+		return true, nil
+	} else if err == ErrNoSuchOwner {
+		return false, nil
+	} else {
+		return false, err
+	}
+}
+
+func (mgr *OwnerManager) SetOwner(
+	owner client.Object,
+	obj metav1.Object,
+	options OwnerOptions,
+) error {
+	if options&Controller != 0 {
+		if err := controllerutil.SetControllerReference(owner, obj, mgr.scheme); err != nil {
+			return err
+		}
+	} else {
+		if err := controllerutil.SetOwnerReference(owner, obj, mgr.scheme); err != nil {
+			return err
+		}
+	}
+	references := obj.GetOwnerReferences()
+	i, err := mgr.findOwnerReferenceIndex(owner, references)
+	if err != nil {
+		return err
+	}
+	ref := &references[i]
+	blockOwnerDeletion := options&BlockOwnerDeletion != 0
+	ref.BlockOwnerDeletion = &blockOwnerDeletion
+	obj.SetOwnerReferences(references)
+
+	return nil
+}
+
+func (mgr *OwnerManager) findOwnerReferenceIndex(owner client.Object, references []metav1.OwnerReference) (int, error) {
+	ownerName := owner.GetName()
+	ownerGVK := owner.GetObjectKind().GroupVersionKind()
+	ownerGV := ownerGVK.GroupVersion()
+	for i, ref := range references {
+		if ref.Name != ownerName || ref.Kind != ownerGVK.Kind {
+			continue
+		}
+		if refGV, err := schema.ParseGroupVersion(ref.APIVersion); err != nil {
+			return -1, err
+		} else if ownerGV == refGV {
+			return i, nil
+		}
+	}
+	return -1, ErrNoSuchOwner
+}

--- a/internal/controller/packageinfo_controller.go
+++ b/internal/controller/packageinfo_controller.go
@@ -22,6 +22,7 @@ import (
 
 	packagesv1alpha1 "github.com/glasskube/glasskube/api/v1alpha1"
 	"github.com/glasskube/glasskube/internal/controller/conditions"
+	"github.com/glasskube/glasskube/internal/controller/owners"
 	"github.com/glasskube/glasskube/internal/controller/requeue"
 	"github.com/glasskube/glasskube/internal/repo"
 	"github.com/glasskube/glasskube/pkg/condition"
@@ -37,6 +38,7 @@ import (
 type PackageInfoReconciler struct {
 	client.Client
 	record.EventRecorder
+	*owners.OwnerManager
 	Scheme *runtime.Scheme
 }
 
@@ -120,6 +122,9 @@ func shouldSyncFromRepo(pi packagesv1alpha1.PackageInfo) bool {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *PackageInfoReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if r.OwnerManager == nil {
+		r.OwnerManager = owners.NewOwnerManager(r.Scheme)
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&packagesv1alpha1.PackageInfo{}).
 		Complete(r)

--- a/internal/manifest/adapter.go
+++ b/internal/manifest/adapter.go
@@ -5,11 +5,12 @@ import (
 
 	packagesv1alpha1 "github.com/glasskube/glasskube/api/v1alpha1"
 	"github.com/glasskube/glasskube/internal/manifest/result"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type ManifestAdapter interface {
-	ControllerInit(builder *builder.Builder) error
-	Reconcile(ctx context.Context, client client.Client, pkg *packagesv1alpha1.Package, manifest *packagesv1alpha1.PackageManifest) (*result.ReconcileResult, error)
+	ControllerInit(builder *builder.Builder, client client.Client, scheme *runtime.Scheme) error
+	Reconcile(ctx context.Context, pkg *packagesv1alpha1.Package, manifest *packagesv1alpha1.PackageManifest) (*result.ReconcileResult, error)
 }

--- a/pkg/client/package.go
+++ b/pkg/client/package.go
@@ -17,7 +17,7 @@ type PackageInterface interface {
 	Get(ctx context.Context, pkgName string, p *v1alpha1.Package) error
 	GetAll(ctx context.Context, result *v1alpha1.PackageList) error
 	Watch(ctx context.Context) (watch.Interface, error)
-	Delete(ctx context.Context, pkg *v1alpha1.Package) error
+	Delete(ctx context.Context, pkg *v1alpha1.Package, options metav1.DeleteOptions) error
 }
 
 type packageClient struct {
@@ -51,10 +51,11 @@ func (c *packageClient) GetAll(ctx context.Context, result *v1alpha1.PackageList
 		Do(ctx).Into(result)
 }
 
-func (c *packageClient) Delete(ctx context.Context, pkg *v1alpha1.Package) error {
+func (c *packageClient) Delete(ctx context.Context, pkg *v1alpha1.Package, options metav1.DeleteOptions) error {
 	return c.restClient.Delete().
 		Resource(packageGVR.Resource).
 		Name(pkg.Name).
+		Body(&options).
 		Do(ctx).Into(nil)
 }
 

--- a/pkg/uninstall/uninstall.go
+++ b/pkg/uninstall/uninstall.go
@@ -5,10 +5,13 @@ import (
 
 	"github.com/glasskube/glasskube/api/v1alpha1"
 	"github.com/glasskube/glasskube/pkg/client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+var deletePropagationForeground = metav1.DeletePropagationForeground
+
 func Uninstall(pkgClient *client.PackageV1Alpha1Client, ctx context.Context, pkg *v1alpha1.Package) error {
-	err := pkgClient.Packages().Delete(ctx, pkg)
+	err := pkgClient.Packages().Delete(ctx, pkg, metav1.DeleteOptions{PropagationPolicy: &deletePropagationForeground})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## 📑 Description
With this PR, foreground deletion is enabled when uninstalling a Package.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information

Note: The uninstall cmd still doesn't wait for the resource to be deleted, but the functionality can be tested using `kubectl delete --cascade=foreground pkg <package-name>`.

* Relevant documentation:
   * https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
   * https://kubernetes.io/docs/tasks/administer-cluster/use-cascading-deletion/#use-foreground-cascading-deletion
* This unblocks #133 and #168