### PR TITLE
feat(cli): add showing package version in list cmd (#200)

### DIFF
--- a/cmd/glasskube/cmd/uninstall.go
+++ b/cmd/glasskube/cmd/uninstall.go
@@ -5,12 +5,15 @@ import (
 	"os"
 
 	"github.com/glasskube/glasskube/internal/cliutils"
-	"github.com/glasskube/glasskube/internal/config"
 	pkgClient "github.com/glasskube/glasskube/pkg/client"
 	"github.com/glasskube/glasskube/pkg/list"
 	"github.com/glasskube/glasskube/pkg/uninstall"
 	"github.com/spf13/cobra"
 )
+
+var uninstallCmdOptions = struct {
+	ForceUninstall bool
+}{}
 
 var uninstallCmd = &cobra.Command{
 	Use:    "uninstall [package-name]",
@@ -27,7 +30,7 @@ var uninstallCmd = &cobra.Command{
 			os.Exit(1)
 			return
 		}
-		proceed := config.ForceUninstall || cliutils.YesNoPrompt(
+		proceed := uninstallCmdOptions.ForceUninstall || cliutils.YesNoPrompt(
 			fmt.Sprintf(
 				"%v will be removed from your cluster (%v). Are you sure?",
 				pkgName,
@@ -51,7 +54,7 @@ var uninstallCmd = &cobra.Command{
 }
 
 func init() {
-	uninstallCmd.PersistentFlags().BoolVar(&config.ForceUninstall, "force", false,
+	uninstallCmd.PersistentFlags().BoolVar(&uninstallCmdOptions.ForceUninstall, "force", false,
 		"skip the confirmation question and uninstall right away")
 	RootCmd.AddCommand(uninstallCmd)
 }

--- a/internal/cliutils/table.go
+++ b/internal/cliutils/table.go
@@ -9,24 +9,28 @@ import (
 	"github.com/glasskube/glasskube/pkg/list"
 )
 
+var tabSep = "\t"
+
 func PrintPackageTable(
 	w io.Writer,
-	packages []*list.PackageTeaserWithStatus,
+	packages []*list.PackageWithStatus,
 	cols []string,
-	getColsOfRow func(pkg *list.PackageTeaserWithStatus) []string,
-) {
+	getColsOfRow func(pkg *list.PackageWithStatus) []string,
+) error {
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	sep := "\t"
-	fmt.Fprintf(tw, "%s\n", strings.Join(cols, sep))
+	fmt.Fprintln(tw, strings.Join(cols, tabSep))
 	var sb strings.Builder
 	for _, pkg := range packages {
 		colsOfRow := getColsOfRow(pkg)
+		if len(colsOfRow) != len(cols) {
+			return fmt.Errorf("column mapping func returned %v columns instead of %v", len(colsOfRow), len(cols))
+		}
 		for _, col := range colsOfRow {
 			sb.WriteString(col)
-			sb.WriteString(sep)
+			sb.WriteString(tabSep)
 		}
-		fmt.Fprintf(tw, "%s\n", sb.String())
+		fmt.Fprintln(tw, sb.String())
 		sb.Reset()
 	}
-	_ = tw.Flush()
+	return tw.Flush()
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,11 +1,8 @@
 package config
 
 var (
-	Kubeconfig        string
-	ForceUninstall    bool
-	ListInstalledOnly bool
-	Verbose           bool
-	Version           = "dev"
-	Commit            = "none"
-	Date              = "unknown"
+	Kubeconfig string
+	Version    = "dev"
+	Commit     = "none"
+	Date       = "unknown"
 )

--- a/internal/repo/types.go
+++ b/internal/repo/types.go
@@ -17,4 +17,5 @@ type PackageRepoIndexItem struct {
 	Name             string `json:"name"`
 	ShortDescription string `json:"shortDescription,omitempty"`
 	IconUrl          string `json:"iconUrl,omitempty"`
+	LatestVersion    string `json:"latestVersion,omitempty"`
 }

--- a/internal/web/components/pkg_overview_btn/controller.go
+++ b/internal/web/components/pkg_overview_btn/controller.go
@@ -35,12 +35,12 @@ func Render(w io.Writer, tmpl *template.Template, pkgName string, status *client
 	})
 }
 
-func ForPkgOverviewBtn(pkgTeaser *list.PackageTeaserWithStatus) *pkgOverviewBtnInput {
-	buttonId := getButtonId(pkgTeaser.PackageName)
+func ForPkgOverviewBtn(pkgTeaser *list.PackageWithStatus) *pkgOverviewBtnInput {
+	buttonId := getButtonId(pkgTeaser.Name)
 	return &pkgOverviewBtnInput{
 		ButtonId:    buttonId,
 		Swap:        "",
-		PackageName: pkgTeaser.PackageName,
+		PackageName: pkgTeaser.Name,
 		Status:      pkgTeaser.Status,
 		Manifest:    pkgTeaser.InstalledManifest,
 	}

--- a/internal/web/templates/pages/packages.html
+++ b/internal/web/templates/pages/packages.html
@@ -7,18 +7,18 @@
           <div class="card-body p-0 d-flex flex-column">
             <div hx-boost="true" class="d-flex align-items-center">
               <div class="flex-shrink-0 px-1 py-1 align-self-center">
-                <a class="text-decoration-none" href="/packages/{{ .PackageName }}">
+                <a class="text-decoration-none" href="/packages/{{ .Name }}">
                   {{if eq .IconUrl ""}}
                   <!-- TODO the glasskube logo as fallback is probably not the best idea? -->
-                  <img src="/static/assets/glasskube-logo.svg" alt="{{ .PackageName}}"  style="width: 3.25rem; height:auto">
+                  <img src="/static/assets/glasskube-logo.svg" alt="{{ .Name}}"  style="width: 3.25rem; height:auto">
                   {{else}}
-                  <img src="{{ .IconUrl }}" alt="{{ .PackageName}}"  style="width: 3.25rem; height:auto">
+                  <img src="{{ .IconUrl }}" alt="{{ .Name }}"  style="width: 3.25rem; height:auto">
                   {{end}}
                 </a>
               </div>
               <div class="flex-grow-1 card-body ps-0 pe-1 py-1 align-self-start">
-                <a class="text-decoration-none" href="/packages/{{ .PackageName }}">
-                  <h6 class="text-dark m-0">{{ .PackageName }}</h6>
+                <a class="text-decoration-none" href="/packages/{{ .Name }}">
+                  <h6 class="text-dark m-0">{{ .Name }}</h6>
                   <span class="lh-sm text-dark overflow-hidden" style="
                         font-size: small;
                         display: -webkit-box;

--- a/website/static/schemas/v1/index.json
+++ b/website/static/schemas/v1/index.json
@@ -12,6 +12,9 @@
         },
         "iconUrl": {
           "type": "string"
+        },
+        "latestVersion": {
+          "type": "string"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #200 <!-- Issue # here -->

## 📑 Description
This PR adds two new columns to the output of `glasskube list`:
* VERSION: shows the installed version plus the spec version and/or available version (from the registry) if they are different
* LATEST VERSION: shows the latest version (from the registry) - Disabled by default

`glasskube list` now has two additional flags: 
* `--show-latest`: enables the LATEST VERSION column (see above)
* `--more` or `-m`: equivalent to `--show-description --show-latest`

## ✅ Checks
- [x] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
I also took the liberty and moved all command specific config variables to their respective command files, as there is no need for a global variable for those.

Some parts of the version column rely on a `latestVersion` being present for the package in the package index (see updated schema file). This is currently not the case and should be done automatically in the future but for testing you will have to set the `latestVersion` yourself in the index.yaml file.