### PR TITLE
fix(ui): use real PackageInfo name when getting installed manifest

### DIFF
--- a/pkg/describe/describe.go
+++ b/pkg/describe/describe.go
@@ -6,7 +6,6 @@ import (
 	"github.com/glasskube/glasskube/api/v1alpha1"
 	"github.com/glasskube/glasskube/internal/repo"
 	"github.com/glasskube/glasskube/pkg/client"
-	"github.com/glasskube/glasskube/pkg/list"
 	"github.com/glasskube/glasskube/pkg/manifest"
 	"k8s.io/apimachinery/pkg/api/errors"
 )
@@ -16,26 +15,26 @@ func DescribePackage(
 	pkgName string,
 ) (*v1alpha1.Package, *client.PackageStatus, *v1alpha1.PackageManifest, error) {
 	pkgClient := client.FromContext(ctx)
-	pkg, err := list.Get(pkgClient, ctx, pkgName)
-	if err != nil && !errors.IsNotFound(err) {
-		return nil, nil, nil, err
-	}
+	var pkg v1alpha1.Package
 	var status *client.PackageStatus
 	var returnedManifest v1alpha1.PackageManifest
-	if pkg != nil {
+	if err := pkgClient.Packages().Get(ctx, pkgName, &pkg); err != nil && !errors.IsNotFound(err) {
+		return nil, nil, nil, err
+	} else if err == nil {
 		// pkg installed: use installed manifest
 		status = client.GetStatusOrPending(&pkg.Status)
-		installedManifest, err := manifest.GetInstalledManifest(ctx, pkgName)
+		installedManifest, err := manifest.GetInstalledManifestForPackage(ctx, pkg)
 		if err != nil {
 			return nil, nil, nil, err
 		}
 		returnedManifest = *installedManifest
 	} else {
+
 		// pkg not installed: use manifest from repo
 		_, err = repo.FetchLatestPackageManifest("", pkgName, &returnedManifest)
 		if err != nil {
 			return nil, nil, nil, err
 		}
 	}
-	return pkg, status, &returnedManifest, nil
+	return &pkg, status, &returnedManifest, nil
 }

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -2,6 +2,7 @@ package manifest
 
 import (
 	"context"
+	"errors"
 
 	"github.com/glasskube/glasskube/pkg/client"
 
@@ -10,9 +11,21 @@ import (
 
 func GetInstalledManifest(ctx context.Context, pkgName string) (*v1alpha1.PackageManifest, error) {
 	pkgClient := client.FromContext(ctx)
+	var pkg v1alpha1.Package
+	if err := pkgClient.Packages().Get(ctx, pkgName, &pkg); err != nil {
+		return nil, err
+	}
+	return GetInstalledManifestForPackage(ctx, pkg)
+}
+
+func GetInstalledManifestForPackage(ctx context.Context, pkg v1alpha1.Package) (*v1alpha1.PackageManifest, error) {
+	pkgClient := client.FromContext(ctx)
+	if len(pkg.Status.OwnedPackageInfos) == 0 {
+		return nil, errors.New("Package has no owned PackageInfo")
+	}
+	packageInfoName := pkg.Status.OwnedPackageInfos[len(pkg.Status.OwnedPackageInfos)-1].Name
 	var packageInfo v1alpha1.PackageInfo
-	// TODO: Change this to use the actual package info name instead of the package name
-	if err := pkgClient.PackageInfos().Get(ctx, pkgName, &packageInfo); err != nil {
+	if err := pkgClient.PackageInfos().Get(ctx, packageInfoName, &packageInfo); err != nil {
 		return nil, err
 	} else {
 		return packageInfo.Status.Manifest, nil


### PR DESCRIPTION
## 📑 Description
If a package has a `.Spec.Version`, the name of the PackageInfo is no longer the same as the package. In such a case, the details page is currently broken. This PR fixes that.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->