### PR TITLE
feat(cli): add installing specific package version (#203)

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -184,9 +184,10 @@ func (s *server) Start(ctx context.Context, support *ServerConfigSupport) error 
 func (s *server) install(w http.ResponseWriter, r *http.Request) {
 	pkgName := r.FormValue("packageName")
 	go func() {
+		// TODO: Add version
 		status, err := install.NewInstaller(s.pkgClient).
 			WithStatusWriter(statuswriter.Stderr()).
-			InstallBlocking(s.ctx, pkgName)
+			InstallBlocking(s.ctx, pkgName, "")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "An error occurred installing %v: \n%v\n", pkgName, err)
 			return

--- a/pkg/client/package.go
+++ b/pkg/client/package.go
@@ -60,14 +60,15 @@ func (c *packageClient) Delete(ctx context.Context, pkg *v1alpha1.Package, optio
 }
 
 // NewPackage instantiates a new v1alpha1.Package struct with the given package name
-func NewPackage(packageName string) *v1alpha1.Package {
+func NewPackage(packageName, version string) *v1alpha1.Package {
 	return &v1alpha1.Package{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: packageName,
 		},
 		Spec: v1alpha1.PackageSpec{
 			PackageInfo: v1alpha1.PackageInfoTemplate{
-				Name: packageName,
+				Name:    packageName,
+				Version: version,
 			},
 		},
 	}

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -28,10 +28,11 @@ func (obj *installer) WithStatusWriter(sw statuswriter.StatusWriter) *installer 
 
 // InstallBlocking creates a new v1alpha1.Package custom resource in the cluster and waits until
 // the package has either status Ready or Failed.
-func (obj *installer) InstallBlocking(ctx context.Context, packageName string) (*client.PackageStatus, error) {
+// An empty version is allowed and is interpreted as "auto-updates enabled".
+func (obj *installer) InstallBlocking(ctx context.Context, packageName, version string) (*client.PackageStatus, error) {
 	obj.status.Start()
 	defer obj.status.Stop()
-	pkg, err := obj.install(ctx, packageName)
+	pkg, err := obj.install(ctx, packageName, version)
 	if err != nil {
 		return nil, err
 	}
@@ -39,16 +40,17 @@ func (obj *installer) InstallBlocking(ctx context.Context, packageName string) (
 }
 
 // Install creates a new v1alpha1.Package custom resource in the cluster.
-func (obj *installer) Install(ctx context.Context, packageName string) error {
+// An empty version is allowed and is interpreted as "auto-updates enabled".
+func (obj *installer) Install(ctx context.Context, packageName, version string) error {
 	obj.status.Start()
 	defer obj.status.Stop()
-	_, err := obj.install(ctx, packageName)
+	_, err := obj.install(ctx, packageName, version)
 	return err
 }
 
-func (obj *installer) install(ctx context.Context, packageName string) (*v1alpha1.Package, error) {
+func (obj *installer) install(ctx context.Context, packageName, version string) (*v1alpha1.Package, error) {
 	obj.status.SetStatus(fmt.Sprintf("Installing %v...", packageName))
-	pkg := client.NewPackage(packageName)
+	pkg := client.NewPackage(packageName, version)
 	err := obj.client.Packages().Create(ctx, pkg)
 	if err != nil {
 		return nil, err

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -112,7 +112,9 @@ Starts the UI server and opens a browser on [http://localhost:8580](http://local
 
 ### `glasskube install <package>`
 
-Installs the given package in your cluster and waits until the installation is either finished successfully or failed.
+Installs the latest version of a package in your cluster and waits until the installation is either finished successfully or failed.
+
+Use `--version=...` if you want to install a specific version of a package, or `--enable-auto-updates` if you want a package to always be updated to the latest version automatically.
 
 ### `glasskube uninstall <package>`
 


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #203  <!-- Issue # here -->

## 📑 Description
This PR adds two additional flags to the `glasskube install` command:
* `--version`: install a specific version of a package
* `--enable-auto-updates`: always keep this package at the latest version

If neither is specified, the user is asked if automatic updates should be enabled. 
If they answer "no", the latest version of the package is fetched and used for installation.

## ✅ Checks
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required

## ℹ Additional Information
Web UI is still TODO.

~Docs will be updated after review.~ Docs updated