### PR TITLE
fix: add path escaping repository urls

### DIFF
--- a/internal/repo/repo.go
+++ b/internal/repo/repo.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
+	"strings"
 
 	packagesv1alpha1 "github.com/glasskube/glasskube/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/util/yaml"
@@ -91,13 +92,13 @@ func getPackageRepoIndexURL(repoURL string) (string, error) {
 }
 
 func getPackageIndexURL(repoURL, name string) (string, error) {
-	return url.JoinPath(getBaseURL(repoURL), name, "versions.yaml")
+	return url.JoinPath(getBaseURL(repoURL), pathEscapeExt(name), "versions.yaml")
 }
 
 func getPackageManifestURL(repoURL, name, version string) (string, error) {
-	pathSegments := []string{name}
+	pathSegments := []string{pathEscapeExt(name)}
 	if version != "" {
-		pathSegments = append(pathSegments, version)
+		pathSegments = append(pathSegments, pathEscapeExt(version))
 	}
 	pathSegments = append(pathSegments, "package.yaml")
 	return url.JoinPath(getBaseURL(repoURL), pathSegments...)
@@ -109,4 +110,10 @@ func getBaseURL(explicitRepositoryURL string) string {
 	} else {
 		return defaultRepositoryURL
 	}
+}
+
+// pathEscapeExt is like url.PathEscape, but additionally escapes "+" characters.
+// This is required due to a bug in the default repository backend.
+func pathEscapeExt(s string) string {
+	return strings.Replace(url.PathEscape(s), "+", url.QueryEscape("+"), -1)
 }


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->


## 📑 Description
Our repository currently does not handle URLs correctly, "+" needs to be escaped, even though it is technically allowed in URL path segments. With this PR, all (non-static) path segments are path-escaped with the addition of "+" being escaped as well.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
Relevant documentation:
* https://datatracker.ietf.org/doc/html/rfc3986#section-2.2 (sub-delims)
* https://datatracker.ietf.org/doc/html/rfc3986#section-3.3 (pchar)