### PR TITLE
feat(cli): change update message to be less obtrusive

### DIFF
--- a/cmd/glasskube/cmd/root.go
+++ b/cmd/glasskube/cmd/root.go
@@ -3,21 +3,33 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/glasskube/glasskube/internal/cliutils"
 	"github.com/glasskube/glasskube/internal/config"
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/spf13/cobra"
 )
 
+var rootCmdOptions struct {
+	SkipUpdateCheck bool
+}
+
 var (
 	RootCmd = cobra.Command{
 		Use:     "glasskube",
 		Version: config.Version,
 		Short:   "🧊 The missing Package Manager for Kubernetes 📦",
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if !rootCmdOptions.SkipUpdateCheck {
+				cliutils.UpdateFetch()
+			}
+		},
 	}
 )
 
 func init() {
+	RootCmd.PersistentFlags().BoolVar(&rootCmdOptions.SkipUpdateCheck, "skip-update-check", config.IsDevBuild(),
+		"Do not check for Glasskube updates")
 	RootCmd.PersistentFlags().StringVar(&config.Kubeconfig, "kubeconfig", "",
 		fmt.Sprintf("path to the kubeconfig file, whose current-context will be used (defaults to %v)",
 			clientcmd.RecommendedHomeFile))

--- a/cmd/glasskube/main.go
+++ b/cmd/glasskube/main.go
@@ -5,11 +5,9 @@ import (
 	"os"
 
 	"github.com/glasskube/glasskube/cmd/glasskube/cmd"
-	"github.com/glasskube/glasskube/internal/cliutils"
 )
 
 func main() {
-	cliutils.UpdateFetch()
 	if err := cmd.RootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/internal/cliutils/checkforupdate.go
+++ b/internal/cliutils/checkforupdate.go
@@ -58,15 +58,8 @@ func checkForUpdate() (bool, string) {
 
 func UpdateFetch() {
 	updateAvailable, latestVersion := checkForUpdate()
-
-	printUpdateMessage := func() {
-		fmt.Fprintf(os.Stderr, "\n   --------------------------------------------------------------------------------------------------------------- \n\n")
-		fmt.Fprintf(os.Stderr, "                                           Update available %s → %s\n", config.Version, latestVersion)
-		fmt.Fprintf(os.Stderr, "                              Please update glasskube to the latest version\n\n")
-		fmt.Fprintf(os.Stderr, "   --------------------------------------------------------------------------------------------------------------- \n\n")
-	}
-
 	if updateAvailable {
-		printUpdateMessage()
+		fmt.Fprintf(os.Stderr, "📣 A newer version of Glasskube is available: %s → %s\n", config.Version, latestVersion)
+		fmt.Fprintf(os.Stderr, "📘 Release notes: https://github.com/glasskube/glasskube/releases/tag/v%v\n\n", latestVersion)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,8 +1,14 @@
 package config
 
+const defaultVersion = "dev"
+
 var (
 	Kubeconfig string
-	Version    = "dev"
+	Version    = defaultVersion
 	Commit     = "none"
 	Date       = "unknown"
 )
+
+func IsDevBuild() bool {
+	return Version == defaultVersion
+}


### PR DESCRIPTION
## 📑 Description
This PR includes several changes to the already existing update check feature:
* It is now less obtrusive and more similar to our other CLI messages
* There is a new (global) `--skip-update-check` flag that does what it says it does
* `--skip-update-check` is `true` by default in development builds (this can be overridden by using `--skip-update-check=false`

## ✅ Checks
- [x] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
I did not update the documentation, I'm not sure if it's even necessary to document the new flag outside of the `help` command…