### PR TITLE
feat(cli): add outdated flag for list cmd (#201)

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -261,7 +261,7 @@ func (s *server) open(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *server) packages(w http.ResponseWriter, r *http.Request) {
-	packages, err := list.GetPackagesWithStatus(s.pkgClient, r.Context(), list.IncludePackageInfos)
+	packages, err := list.GetPackagesWithStatus(s.pkgClient, r.Context(), list.ListOptions{IncludePackageInfos: true})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "could not load packages: %v\n", err)
 		return

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -129,7 +129,8 @@ Removes the given package from your cluster.
 
 Lists packages. By default, all packages available in the configured repository are shown, including their installation status in the given cluster.
 
-With the `--installed` flag you can restrict the list of packages to the once installed in your cluster.
+With the `--installed` flag you can restrict the list of packages to the ones installed in your cluster.
+If you only want to see installed packages that have a newer version available, use the `--outdated` flag.
 
 ### `glasskube open <package>`
 


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #201 <!-- Issue # here -->

## 📑 Description
This PR adds a a new flag `--outdated` to the list subcommand. This flag is false by default. If it is set to true, the output is restricted to those packages with an outdated version.

## ✅ Checks
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required

## ℹ Additional Information
I also refactored the ListOptions type from an int type to a struct because I think it is much more convenient and less error prone.