### PR TITLE
feat(ui): add current context in navbar (#263)

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -292,7 +292,10 @@ func (s *server) packages(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(os.Stderr, "could not load packages: %v\n", err)
 		return
 	}
-	err = pkgsPageTmpl.Execute(w, packages)
+	err = pkgsPageTmpl.Execute(w, map[string]any{
+		"CurrentContext": s.rawConfig.CurrentContext,
+		"Packages":       packages,
+	})
 	checkTmplError(err, "packages")
 }
 
@@ -308,10 +311,11 @@ func (s *server) packageDetail(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(os.Stderr, "An error occurred fetching latest version of %v: \n%v\n", pkgName, err)
 	}
 	err = pkgPageTmpl.Execute(w, &map[string]any{
-		"Package":       pkg,
-		"Status":        status,
-		"Manifest":      manifest,
-		"LatestVersion": latestVersion,
+		"CurrentContext": s.rawConfig.CurrentContext,
+		"Package":        pkg,
+		"Status":         status,
+		"Manifest":       manifest,
+		"LatestVersion":  latestVersion,
 	})
 	checkTmplError(err, fmt.Sprintf("package-detail (%s)", pkgName))
 }
@@ -355,8 +359,8 @@ func (s *server) bootstrapPage(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		tplErr := bootstrapPageTmpl.Execute(w, &map[string]any{
-			"Err":            err,
 			"CurrentContext": s.rawConfig.CurrentContext,
+			"Err":            err,
 		})
 		checkTmplError(tplErr, "bootstrap")
 	}
@@ -388,9 +392,9 @@ func (s *server) kubeconfigPage(w http.ResponseWriter, r *http.Request) {
 		currentContext = s.rawConfig.CurrentContext
 	}
 	tplErr := kubeconfigPageTmpl.Execute(w, map[string]any{
+		"CurrentContext":            currentContext,
 		"ConfigErr":                 configErr,
 		"KubeconfigDefaultLocation": clientcmd.RecommendedHomeFile,
-		"CurrentContext":            currentContext,
 		"DefaultKubeconfigExists":   defaultKubeconfigExists(),
 	})
 	checkTmplError(tplErr, "kubeconfig")

--- a/internal/web/templates/layout/base.html
+++ b/internal/web/templates/layout/base.html
@@ -44,7 +44,12 @@
     </ul>
 
     <div class="navbar-collapse">
-      <ul class="navbar-nav ms-auto">
+      <ul class="navbar-nav ms-auto align-items-center gap-1">
+        {{if .CurrentContext}}
+        <li class="nav-item">
+          <span class="nav-link">Context: {{.CurrentContext}}</span>
+        </li>
+        {{end}}
         <li class="nav-item">
           <a class="cta cta-sm text-white" href="https://github.com/glasskube/glasskube" target="_blank">
             <span class="bi bi-github"></span>

--- a/internal/web/templates/pages/packages.html
+++ b/internal/web/templates/pages/packages.html
@@ -1,7 +1,7 @@
 {{define "body"}}
 <div class="container-lg mt-4" hx-trigger="htmx:historyRestore from:body" hx-get="/packages" hx-select="main" hx-target="main">
   <div class="row row-cols-3 row-cols-xl-4 g-2">
-    {{range .}}
+    {{range .Packages}}
       <div class="col">
         <div class="card h-100 border-primary border-1">
           <div class="card-body p-0 d-flex flex-column">


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #263 <!-- Issue # here -->

## 📑 Description
With this PR, the currentContext from the selected kubeconfig is always shown in the navbar of the UI:

![image](https://github.com/glasskube/glasskube/assets/16959694/6f772aba-65a1-4668-8fbe-a2aca0976d2f)

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
Placement/Visuals are up for discussion.