### PR TITLE
build: use glasskube/theme dependency from npmjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "glasskube-pm",
+  "name": "glasskube",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -757,8 +757,8 @@
     },
     "node_modules/@glasskube/theme": {
       "version": "0.1.1",
-      "resolved": "https://npm.pkg.github.com/download/@glasskube/theme/0.1.1/5298002ffc3f8d22f702db43b9d456224c938029",
-      "integrity": "sha512-w+lmH/l/XAP5GgiXg7L/EfiJkqTpOqe3GWwQEeuglPmWe+XyUX/EdEvEohbxpal4lwSqv6SdTDHkc+M9pFCaGg==",
+      "resolved": "https://registry.npmjs.org/@glasskube/theme/-/theme-0.1.1.tgz",
+      "integrity": "sha512-M/szbR5bF7O4j1JGDnAqXuyRfIdkfq9ZE04EbEqON9dQ7Gg1ZTS9BCQhBfsFedy4z5s2ZgRhECRXbg8mJO2EcQ==",
       "dependencies": {
         "@fontsource/inter": "5.0.16",
         "@fontsource/poppins": "5.0.8",
@@ -785,9 +785,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.11.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.23.tgz",
-      "integrity": "sha512-ZUarKKfQuRILSNYt32FuPL20HS7XwNT7/uRwSV8tiHWfyyVwDLYZNF6DZKc2bove++pgfsXn9sUwII/OsQ82cQ==",
+      "version": "20.11.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.24.tgz",
+      "integrity": "sha512-Kza43ewS3xoLgCEpQrsT+xRo/EJej1y0kVYGiLFE1NEODXGzTfwiC6tXTLMQskn1X4/Rjlh0MQUvx9W+L9long==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->

## 📑 Description
Previously the build failed, because the package-lock.json file directed the new @glasskube/theme dependency to the "private" github package instead of the npmjs package.

The change has been done by removing the private auth token from my local .npmrc file, removing node_modules and reinstall dependencies with `npm i` – npm then uses the npmjs package instead of the github one. Probably there would have been a better way but this seems to work. However, if one changes back to have the auth token in the .npmrc file, the Github registry is used preferrably by npm.

For the future, I think it would be better to not publish the theme to the github registry at all to avoid this.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
Related #313 