### PR TITLE
ci: add upload-artifact step for build action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,6 +27,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - run: make all
+      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        with:
+          name: artifacts-${{ runner.os }}-${{ runner.arch }}
+          path: dist/
       - name: Check if repository is clean
         run: |
           STATUS="$(git status --porcelain)"


### PR DESCRIPTION
## 📑 Description
This PR adds attaching the built binaries as artifacts to the GitHub workflow run

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->