### PR TITLE
feat(package-operator): add handling of packages with helm and manifests

### DIFF
--- a/cmd/package-operator/main.go
+++ b/cmd/package-operator/main.go
@@ -35,6 +35,7 @@ import (
 	packagesv1alpha1 "github.com/glasskube/glasskube/api/v1alpha1"
 	"github.com/glasskube/glasskube/internal/controller"
 	"github.com/glasskube/glasskube/internal/manifest/helm/flux"
+	"github.com/glasskube/glasskube/internal/manifest/plain"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -91,10 +92,11 @@ func main() {
 	}
 
 	if err = (&controller.PackageReconciler{
-		Client:        mgr.GetClient(),
-		EventRecorder: mgr.GetEventRecorderFor("package-controller"),
-		Scheme:        mgr.GetScheme(),
-		Helm:          flux.NewAdapter(),
+		Client:          mgr.GetClient(),
+		EventRecorder:   mgr.GetEventRecorderFor("package-controller"),
+		Scheme:          mgr.GetScheme(),
+		HelmAdapter:     flux.NewAdapter(),
+		ManifestAdapter: plain.NewAdapter(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Package")
 		os.Exit(1)

--- a/internal/controller/owners/utils/owned_resources.go
+++ b/internal/controller/owners/utils/owned_resources.go
@@ -1,0 +1,99 @@
+package utils
+
+import (
+	"errors"
+
+	packagesv1alpha1 "github.com/glasskube/glasskube/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func RefersToSameResource(a, b packagesv1alpha1.OwnedResourceRef) bool {
+	return a.Group == b.Group &&
+		a.Version == b.Version &&
+		a.Kind == b.Kind &&
+		a.Name == b.Name &&
+		a.Namespace == b.Namespace
+}
+
+func Add(refs *[]packagesv1alpha1.OwnedResourceRef, newRefs ...packagesv1alpha1.OwnedResourceRef) bool {
+	var changed bool
+outer:
+	for _, newRef := range newRefs {
+		for _, ref := range *refs {
+			if RefersToSameResource(ref, newRef) {
+				continue outer
+			}
+		}
+		*refs = append(*refs, newRef)
+		changed = true
+	}
+	return changed
+}
+
+func Remove(refs *[]packagesv1alpha1.OwnedResourceRef, toRemove packagesv1alpha1.OwnedResourceRef) bool {
+	for i, ref := range *refs {
+		if RefersToSameResource(ref, toRemove) {
+			*refs = append((*refs)[0:i], (*refs)[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
+func AddOwnedResourceRef(
+	scheme *runtime.Scheme,
+	refs *[]packagesv1alpha1.OwnedResourceRef,
+	obj client.Object,
+) (bool, error) {
+	if ref, err := ToOwnedResourceRef(scheme, obj); err != nil {
+		return false, err
+	} else {
+		return Add(refs, ref), nil
+	}
+}
+
+func RemoveOwnedResourceRef(refs *[]packagesv1alpha1.OwnedResourceRef, ref packagesv1alpha1.OwnedResourceRef) {
+	for i, r := range *refs {
+		if RefersToSameResource(r, ref) {
+			*refs = append((*refs)[:i], (*refs)[i+1:]...)
+			return
+		}
+	}
+}
+
+func ToOwnedResourceRef(scheme *runtime.Scheme, obj client.Object) (packagesv1alpha1.OwnedResourceRef, error) {
+	if gvk, err := getGVK(scheme, obj); err != nil {
+		return packagesv1alpha1.OwnedResourceRef{}, err
+	} else {
+		return packagesv1alpha1.OwnedResourceRef{
+			GroupVersionKind: gvk,
+			Name:             obj.GetName(),
+			Namespace:        obj.GetNamespace(),
+		}, nil
+	}
+}
+
+func OwnedResourceRefToObject(ref packagesv1alpha1.OwnedResourceRef) client.Object {
+	obj := unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind(ref.GroupVersionKind))
+	obj.SetName(ref.Name)
+	obj.SetNamespace(ref.Namespace)
+	return &obj
+}
+
+func getGVK(scheme *runtime.Scheme, obj client.Object) (metav1.GroupVersionKind, error) {
+	if gvks, _, err := scheme.ObjectKinds(obj); err != nil {
+		return metav1.GroupVersionKind{}, err
+	} else {
+		for _, gvk := range gvks {
+			if len(gvk.Kind) > 0 && len(gvk.Version) > 0 {
+				return metav1.GroupVersionKind(gvk), nil
+			}
+		}
+	}
+	return metav1.GroupVersionKind{}, errors.New("could not find a usable GroupVersionKind for object")
+}

--- a/internal/controller/owners/utils/owners.go
+++ b/internal/controller/owners/utils/owners.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ObjHasOwner(obj, owner client.Object) (bool, error) {
+	refs := obj.GetOwnerReferences()
+	for _, ref := range refs {
+		if ref.Name != owner.GetName() {
+			continue
+		}
+		if gv, err := schema.ParseGroupVersion(ref.APIVersion); err != nil {
+			return false, err
+		} else if owner.GetObjectKind().GroupVersionKind() == gv.WithKind(ref.Kind) {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/internal/controller/requeue/requeue.go
+++ b/internal/controller/requeue/requeue.go
@@ -17,10 +17,20 @@ func Always(ctx context.Context, err error) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
 	if err != nil {
 		log.Error(err, "error during reconciliation")
-		return requeueAfter(ErrorRequeueDuration), nil
+		return ctrl.Result{}, err
 	}
 	log.V(1).Info("reconciliation finished")
 	return requeueAfter(RequeueDuration), nil
+}
+
+func OnError(ctx context.Context, err error) (ctrl.Result, error) {
+	log := log.FromContext(ctx)
+	if err != nil {
+		log.Error(err, "error during reconciliation")
+	} else {
+		log.V(1).Info("reconciliation finished")
+	}
+	return ctrl.Result{}, err
 }
 
 func requeueAfter(duration time.Duration) ctrl.Result {

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -3,77 +3,12 @@ package controller
 import (
 	"regexp"
 	"strings"
-
-	packagesv1alpha1 "github.com/glasskube/glasskube/api/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
 	resourceNameRegex = regexp.MustCompile(`[^\w.-]`)
 )
 
-func objHasOwner(obj, owner client.Object) (bool, error) {
-	refs := obj.GetOwnerReferences()
-	for _, ref := range refs {
-		if ref.Name != owner.GetName() {
-			continue
-		}
-		if gv, err := schema.ParseGroupVersion(ref.APIVersion); err != nil {
-			return false, err
-		} else if owner.GetObjectKind().GroupVersionKind() == gv.WithKind(ref.Kind) {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
 func escapeResourceName(name string) string {
 	return strings.ToLower(resourceNameRegex.ReplaceAllString(name, "--"))
-}
-
-func refersToSameResource(a, b packagesv1alpha1.OwnedResourceRef) bool {
-	return a.Group == b.Group &&
-		a.Version == b.Version &&
-		a.Kind == b.Kind &&
-		a.Name == b.Name &&
-		a.Namespace == b.Namespace
-}
-
-func addOwnedResourceRef(refs *[]packagesv1alpha1.OwnedResourceRef, kind schema.ObjectKind, obj metav1.Object) bool {
-	newRef := toOwnedResourceRef(kind, obj)
-	for _, ref := range *refs {
-		if refersToSameResource(ref, newRef) {
-			return false
-		}
-	}
-	*refs = append(*refs, newRef)
-	return true
-}
-
-func removeOwnedResourceRef(refs *[]packagesv1alpha1.OwnedResourceRef, ref packagesv1alpha1.OwnedResourceRef) {
-	for i, r := range *refs {
-		if refersToSameResource(r, ref) {
-			*refs = append((*refs)[:i], (*refs)[i+1:]...)
-			return
-		}
-	}
-}
-
-func toOwnedResourceRef(kind schema.ObjectKind, obj metav1.Object) packagesv1alpha1.OwnedResourceRef {
-	return packagesv1alpha1.OwnedResourceRef{
-		GroupVersionKind: metav1.GroupVersionKind(kind.GroupVersionKind()),
-		Name:             obj.GetName(),
-		Namespace:        obj.GetNamespace(),
-	}
-}
-
-func ownedResourceRefToObject(ref packagesv1alpha1.OwnedResourceRef) client.Object {
-	obj := unstructured.Unstructured{}
-	obj.SetGroupVersionKind(schema.GroupVersionKind(ref.GroupVersionKind))
-	obj.SetName(ref.Name)
-	obj.SetNamespace(ref.Namespace)
-	return &obj
 }

--- a/internal/manifest/plain/adapter.go
+++ b/internal/manifest/plain/adapter.go
@@ -1,0 +1,86 @@
+package plain
+
+import (
+	"context"
+	"fmt"
+
+	packagesv1alpha1 "github.com/glasskube/glasskube/api/v1alpha1"
+	"github.com/glasskube/glasskube/internal/clientutils"
+	"github.com/glasskube/glasskube/internal/controller/owners"
+	ownerutils "github.com/glasskube/glasskube/internal/controller/owners/utils"
+	"github.com/glasskube/glasskube/internal/manifest"
+	"github.com/glasskube/glasskube/internal/manifest/result"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var fieldOwner = client.FieldOwner("packages.glasskube.dev/package-controller")
+
+type Adapter struct {
+	client.Client
+	*owners.OwnerManager
+}
+
+func NewAdapter() manifest.ManifestAdapter {
+	return &Adapter{}
+}
+
+// ControllerInit implements manifest.ManifestAdapter.
+func (a *Adapter) ControllerInit(builder *builder.Builder, client client.Client, scheme *runtime.Scheme) error {
+	if a.OwnerManager == nil {
+		a.OwnerManager = owners.NewOwnerManager(scheme)
+	}
+	a.Client = client
+	return nil
+}
+
+// Reconcile implements manifest.ManifestAdapter.
+func (a *Adapter) Reconcile(
+	ctx context.Context,
+	pkg *packagesv1alpha1.Package,
+	manifest *packagesv1alpha1.PackageManifest,
+) (*result.ReconcileResult, error) {
+	var allOwned []packagesv1alpha1.OwnedResourceRef
+	for _, m := range manifest.Manifests {
+		if owned, err := a.reconcilePlainManifest(ctx, *pkg, m); err != nil {
+			return nil, err
+		} else {
+			allOwned = append(allOwned, owned...)
+		}
+	}
+	return result.Ready(fmt.Sprintf("%v manifests reconciled", len(allOwned)), allOwned), nil
+}
+
+func (r *Adapter) reconcilePlainManifest(
+	ctx context.Context,
+	pkg packagesv1alpha1.Package,
+	manifest packagesv1alpha1.PlainManifest,
+) ([]packagesv1alpha1.OwnedResourceRef, error) {
+	log := ctrl.LoggerFrom(ctx)
+	objectsToApply, err := clientutils.FetchResources(manifest.Url)
+	if err != nil {
+		return nil, err
+	}
+	log.V(1).Info("fetched "+manifest.Url, "objectCount", len(*objectsToApply))
+
+	ownedResources := make([]packagesv1alpha1.OwnedResourceRef, 0, len(*objectsToApply))
+
+	// TODO: check if namespace is terminating before applying
+
+	for _, obj := range *objectsToApply {
+		if err := r.SetOwner(&pkg, &obj, owners.BlockOwnerDeletion); err != nil {
+			return nil, fmt.Errorf("could set owner reference: %w", err)
+		}
+		if err := r.Patch(ctx, &obj, client.Apply, fieldOwner, client.ForceOwnership); err != nil {
+			return nil, fmt.Errorf("could not apply resource: %w", err)
+		}
+		log.V(1).Info("applied resource",
+			"kind", obj.GroupVersionKind(), "namespace", obj.GetNamespace(), "name", obj.GetName())
+		if _, err := ownerutils.AddOwnedResourceRef(r.Scheme(), &ownedResources, &obj); err != nil {
+			return nil, err
+		}
+	}
+	return ownedResources, nil
+}

--- a/internal/manifest/result/result.go
+++ b/internal/manifest/result/result.go
@@ -1,5 +1,7 @@
 package result
 
+import "github.com/glasskube/glasskube/api/v1alpha1"
+
 type resultKind int
 
 const (
@@ -9,20 +11,21 @@ const (
 )
 
 type ReconcileResult struct {
-	kind    resultKind
-	Message string
+	kind           resultKind
+	Message        string
+	OwnedResources []v1alpha1.OwnedResourceRef
 }
 
-func Ready(message string) *ReconcileResult {
-	return &ReconcileResult{kind: ready, Message: message}
+func Ready(message string, ownedResources []v1alpha1.OwnedResourceRef) *ReconcileResult {
+	return &ReconcileResult{kind: ready, Message: message, OwnedResources: ownedResources}
 }
 
-func Waiting(message string) *ReconcileResult {
-	return &ReconcileResult{kind: waiting, Message: message}
+func Waiting(message string, ownedResources []v1alpha1.OwnedResourceRef) *ReconcileResult {
+	return &ReconcileResult{kind: waiting, Message: message, OwnedResources: ownedResources}
 }
 
-func Failed(message string) *ReconcileResult {
-	return &ReconcileResult{kind: failed, Message: message}
+func Failed(message string, ownedResources []v1alpha1.OwnedResourceRef) *ReconcileResult {
+	return &ReconcileResult{kind: failed, Message: message, OwnedResources: ownedResources}
 }
 
 func (r *ReconcileResult) IsReady() bool {


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #328 <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->
This PR changes the way the package controller operators pretty significantly: Previously, we updated the package status intermittently in some cases, but deferred updates to the end, risking missing data in case of an error, in others. Both approaches are not ideal were used inconsistently. 

With this change, the package status is only updated once per reconciliation. The update is performed as the last step, whether an error has occurred or not. This means that we no longer lose track of owned resources that were created before an error occurred. 

HelmReleases and HelmRepositories created by the FluxHelmAdapter are now also tracked as owned resources.

It is now possible to support both helm and manifests in a package. This allows package authors to include additional resources not provided by the helm chart. 

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->