### PR TITLE
feat(package-operator): add default namespace handling for plain manifests

### DIFF
--- a/api/v1alpha1/package_manifest.go
+++ b/api/v1alpha1/package_manifest.go
@@ -47,6 +47,10 @@ type PackageEntrypoint struct {
 
 type PlainManifest struct {
 	Url string `json:"url" jsonschema:"required"`
+	// DefaultNamespace, if set to a non-empty string, is used for resources that are of a namespaced
+	// kind and do not have a namespace set.
+	// If at least one such a resource exists, the namespace is created implicitly.
+	DefaultNamespace string `json:"defaultNamespace,omitempty"`
 }
 
 type PackageReference struct {

--- a/config/crd/bases/packages.glasskube.dev_packageinfos.yaml
+++ b/config/crd/bases/packages.glasskube.dev_packageinfos.yaml
@@ -215,6 +215,12 @@ spec:
                   manifests:
                     items:
                       properties:
+                        defaultNamespace:
+                          description: |-
+                            DefaultNamespace, if set to a non-empty string, is used for resources that are of a namespaced
+                            kind and do not have a namespace set.
+                            If at least one such a resource exists, the namespace is created implicitly.
+                          type: string
                         url:
                           type: string
                       required:

--- a/website/static/schemas/v1/package-manifest.json
+++ b/website/static/schemas/v1/package-manifest.json
@@ -94,6 +94,9 @@
       "properties": {
         "url": {
           "type": "string"
+        },
+        "defaultNamespace": {
+          "type": "string"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #333 

## 📑 Description
<!-- Add a brief description of the pr -->
This PR adds a `defaultNamespace` property to plain manifests. 
If a plain mainfest includes resources of a namespaced kind that do not have a namespace set, they will be created in the default namespace. 

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
Required for https://github.com/glasskube/packages/pull/41