### PR TITLE
build: change goreleaser config to only include cli in artifacts

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,7 +16,8 @@ before:
     - hack/generate-manifests.sh
 
 builds:
-  - env:
+  - id: glasskube
+    env:
       - CGO_ENABLED=0
     goos:
       - linux
@@ -98,6 +99,8 @@ nfpms:
         dst: /usr/share/doc/nfpm/copyright
         file_info:
           mode: 0644
+    builds:
+      - glasskube
 
 brews:
   - name: glasskube
@@ -138,7 +141,8 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
-    allow_different_binary_count: true
+    builds:
+      - glasskube
 
 changelog:
   disable: true


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->


## 📑 Description
Until now, our release archives and installers included both the glasskube CLI and package-operator binaries. With this PR, only the glasskube CLI is included.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
To test: `goreleaser release --snapshot --clean` (this will skip all publishing steps)