### PR TITLE
feat: add version mismatch detection for PackageOperator

### DIFF
--- a/cmd/glasskube/cmd/bootstrap.go
+++ b/cmd/glasskube/cmd/bootstrap.go
@@ -26,7 +26,7 @@ var bootstrapCmd = &cobra.Command{
 	Long: "Bootstraps Glasskube in a Kubernetes cluster, " +
 		"thereby installing the Glasskube operator and checking if the installation was successful.",
 	Args:   cobra.NoArgs,
-	PreRun: cliutils.SetupClientContext(false),
+	PreRun: cliutils.SetupClientContext(false, &rootCmdOptions.SkipUpdateCheck),
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg, _ := cliutils.RequireConfig(config.Kubeconfig)
 		client := bootstrap.NewBootstrapClient(cfg)

--- a/cmd/glasskube/cmd/describe.go
+++ b/cmd/glasskube/cmd/describe.go
@@ -21,7 +21,7 @@ var describeCmd = &cobra.Command{
 	Short:             "Describe a package",
 	Long:              "Shows additional information about the given package.",
 	Args:              cobra.ExactArgs(1),
-	PreRun:            cliutils.SetupClientContext(true),
+	PreRun:            cliutils.SetupClientContext(true, &rootCmdOptions.SkipUpdateCheck),
 	ValidArgsFunction: completeAvailablePackageNames,
 	Run: func(cmd *cobra.Command, args []string) {
 		pkgName := args[0]

--- a/cmd/glasskube/cmd/install.go
+++ b/cmd/glasskube/cmd/install.go
@@ -32,7 +32,7 @@ var installCmd = &cobra.Command{
 	Short:             "Install a package",
 	Long:              `Install a package.`,
 	Args:              cobra.ExactArgs(1),
-	PreRun:            cliutils.SetupClientContext(true),
+	PreRun:            cliutils.SetupClientContext(true, &rootCmdOptions.SkipUpdateCheck),
 	ValidArgsFunction: completeAvailablePackageNames,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()

--- a/cmd/glasskube/cmd/list.go
+++ b/cmd/glasskube/cmd/list.go
@@ -34,7 +34,7 @@ var listCmd = &cobra.Command{
 	Short:   "List packages",
 	Long: "List packages. By default, all available packages of the given repository are shown, " +
 		"as well as their installation status in your cluster.\nYou can choose to only show installed packages.",
-	PreRun: cliutils.SetupClientContext(true),
+	PreRun: cliutils.SetupClientContext(true, &rootCmdOptions.SkipUpdateCheck),
 	Run: func(cmd *cobra.Command, args []string) {
 		if listCmdOptions.More {
 			listCmdOptions.ShowLatestVersion = true

--- a/cmd/glasskube/cmd/open.go
+++ b/cmd/glasskube/cmd/open.go
@@ -17,7 +17,7 @@ var openCmd = &cobra.Command{
 	Long: `Open the Web UI of a package.
 If the package manifest has more than one entrypoint, specify the name of the entrypoint to open.`,
 	Args:   cobra.RangeArgs(1, 2),
-	PreRun: cliutils.SetupClientContext(true),
+	PreRun: cliutils.SetupClientContext(true, &rootCmdOptions.SkipUpdateCheck),
 	Run: func(cmd *cobra.Command, args []string) {
 		pkgName := args[0]
 		var entrypointName string

--- a/cmd/glasskube/cmd/uninstall.go
+++ b/cmd/glasskube/cmd/uninstall.go
@@ -22,7 +22,7 @@ var uninstallCmd = &cobra.Command{
 	Short:  "Uninstall a package",
 	Long:   `Uninstall a package.`,
 	Args:   cobra.ExactArgs(1),
-	PreRun: cliutils.SetupClientContext(true),
+	PreRun: cliutils.SetupClientContext(true, &rootCmdOptions.SkipUpdateCheck),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := pkgClient.FromContext(cmd.Context())
 		pkgName := args[0]

--- a/cmd/glasskube/cmd/update.go
+++ b/cmd/glasskube/cmd/update.go
@@ -20,7 +20,7 @@ import (
 var updateCmd = &cobra.Command{
 	Use:               "update [packages...]",
 	Short:             "Update some or all packages in your cluster",
-	PreRun:            cliutils.SetupClientContext(true),
+	PreRun:            cliutils.SetupClientContext(true, &rootCmdOptions.SkipUpdateCheck),
 	ValidArgsFunction: completeInstalledPackageNames,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()

--- a/cmd/glasskube/cmd/version.go
+++ b/cmd/glasskube/cmd/version.go
@@ -1,17 +1,12 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"os"
 
 	"github.com/glasskube/glasskube/internal/cliutils"
 	"github.com/glasskube/glasskube/internal/config"
-	"github.com/glasskube/glasskube/pkg/client"
-	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/spf13/cobra"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 )
 
 var versioncmd = &cobra.Command{
@@ -22,7 +17,7 @@ var versioncmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		glasskubeVersion := config.Version
 		fmt.Fprintf(os.Stderr, "glasskube: v%s\n", glasskubeVersion)
-		operatorVersion, err := getPackageOperatorVersion(cmd.Context())
+		operatorVersion, err := cliutils.GetPackageOperatorVersion(cmd.Context())
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "✗ no deployments found in the glasskube-system namespace\n")
 		} else {
@@ -33,31 +28,4 @@ var versioncmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(versioncmd)
-}
-
-func getPackageOperatorVersion(ctx context.Context) (string, error) {
-	config := client.ConfigFromContext(ctx)
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return "", err
-	}
-
-	namespace := "glasskube-system"
-	deploymentName := "glasskube-controller-manager"
-	deployment, err := clientset.AppsV1().Deployments(namespace).Get(ctx, deploymentName, metav1.GetOptions{})
-	if err != nil {
-		return "", err
-	}
-
-	containers := deployment.Spec.Template.Spec.Containers
-	for _, container := range containers {
-		if container.Name == "manager" {
-			ref, err := name.ParseReference(container.Image)
-			if err != nil {
-				return "", err
-			}
-			return ref.Identifier(), nil
-		}
-	}
-	return "", nil
 }

--- a/cmd/glasskube/cmd/version.go
+++ b/cmd/glasskube/cmd/version.go
@@ -13,7 +13,7 @@ var versioncmd = &cobra.Command{
 	Use:    "version",
 	Short:  "Print the version of glasskube and package-operator",
 	Long:   `Print the version of glasskube and package-operator`,
-	PreRun: cliutils.SetupClientContext(false),
+	PreRun: cliutils.SetupClientContext(false, &rootCmdOptions.SkipUpdateCheck),
 	Run: func(cmd *cobra.Command, args []string) {
 		glasskubeVersion := config.Version
 		fmt.Fprintf(os.Stderr, "glasskube: v%s\n", glasskubeVersion)

--- a/internal/cliutils/setupclientcontext.go
+++ b/internal/cliutils/setupclientcontext.go
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func SetupClientContext(requireBootstrapped bool) func(cmd *cobra.Command, args []string) {
+func SetupClientContext(requireBootstrapped bool, skipUpdateCheck *bool) func(cmd *cobra.Command, args []string) {
 	return func(cmd *cobra.Command, args []string) {
 		cfg, rawCfg := RequireConfig(config.Kubeconfig)
 		if requireBootstrapped {
@@ -26,8 +26,10 @@ func SetupClientContext(requireBootstrapped bool) func(cmd *cobra.Command, args 
 		} else {
 			cmd.SetContext(ctx)
 		}
-		if err := CheckPackageOperatorVersion(cmd.Context()); err != nil {
-			fmt.Fprintf(os.Stderr, "Error checking PackageOperator version:\n\n%v\n", err)
+		if !*skipUpdateCheck {
+			if err := CheckPackageOperatorVersion(cmd.Context()); err != nil {
+				fmt.Fprintf(os.Stderr, "Error checking PackageOperator version:\n\n%v\n", err)
+			}
 		}
 	}
 }

--- a/internal/cliutils/setupclientcontext.go
+++ b/internal/cliutils/setupclientcontext.go
@@ -26,6 +26,9 @@ func SetupClientContext(requireBootstrapped bool) func(cmd *cobra.Command, args 
 		} else {
 			cmd.SetContext(ctx)
 		}
+		if err := CheckPackageOperatorVersion(cmd.Context()); err != nil {
+			fmt.Fprintf(os.Stderr, "Error checking PackageOperator version:\n\n%v\n", err)
+		}
 	}
 }
 

--- a/internal/cliutils/versionutil.go
+++ b/internal/cliutils/versionutil.go
@@ -1,0 +1,52 @@
+package cliutils
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/glasskube/glasskube/internal/config"
+	"github.com/glasskube/glasskube/pkg/client"
+	"github.com/google/go-containerregistry/pkg/name"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func GetPackageOperatorVersion(ctx context.Context) (string, error) {
+	config := client.ConfigFromContext(ctx)
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return "", err
+	}
+
+	namespace := "glasskube-system"
+	deploymentName := "glasskube-controller-manager"
+	deployment, err := clientset.AppsV1().Deployments(namespace).Get(ctx, deploymentName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	containers := deployment.Spec.Template.Spec.Containers
+	for _, container := range containers {
+		if container.Name == "manager" {
+			ref, err := name.ParseReference(container.Image)
+			if err != nil {
+				return "", err
+			}
+			return ref.Identifier(), nil
+		}
+	}
+	return "", nil
+}
+
+func CheckPackageOperatorVersion(ctx context.Context) error {
+	operatorVersion, err := GetPackageOperatorVersion(ctx)
+	if err != nil {
+		return err
+	}
+	if operatorVersion[1:] != config.Version {
+		fmt.Fprintf(os.Stderr, "❗ Glasskube PackageOperator needs to be updated: %s -> %s\n", operatorVersion[1:], config.Version)
+		fmt.Fprintf(os.Stderr, "💡 Please run `glasskube bootstrap` again to update Glasskube PackageOperator\n")
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue #205  -->

## 📑 Description
<!-- Add a brief description of the pr -->
This PR adds a feature to detect version mismatch between PackageOperator & CLI and notifies the user.
  
**Changes Made:**
Moved GetPackageOperatorVersion() to `glasskube/internal/cliutils/versionutil.go`
added CheckPackageOperatorVersion() function
Added `--skip-update-check ` flag support to skip update checks

```
 $ ./glasskube list --skip-update-check=false
❗ Glasskube PackageOperator needs to be updated: 0.0.4 -> dev
💡 Please run `glasskube bootstrap` again to update Glasskube PackageOperator
NAME                  STATUS         VERSION
argo-cd               Not installed    
cert-manager          Not installed    
cyclops               Not installed    
ingress-nginx         Not installed    
keptn                 Not installed    
kubernetes-dashboard  Not installed    
```
```
$ ./glasskube version
❗ Glasskube PackageOperator needs to be updated: 0.0.4 -> dev
💡 Please run `glasskube bootstrap` again to update Glasskube PackageOperator
glasskube: vdev
package-operator: v0.0.4
```

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->