### PR TITLE
fix: consider semver metadata when comparing installed vs latest version (#397)

### DIFF
--- a/internal/cliutils/checkforupdate.go
+++ b/internal/cliutils/checkforupdate.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/Masterminds/semver/v3"
 	"github.com/glasskube/glasskube/internal/config"
 	"github.com/glasskube/glasskube/internal/releaseinfo"
+	"github.com/glasskube/glasskube/internal/semver"
 )
 
 // CheckForUpdate determines the new version by fetching the latest release info.
@@ -16,11 +16,7 @@ func CheckForUpdate() (*string, error) {
 		return nil, err
 	} else if config.IsDevBuild() {
 		return &releaseInfo.Version, nil
-	} else if version, err := semver.NewVersion(config.Version); err != nil {
-		return nil, err
-	} else if latestVersion, err := semver.NewVersion(releaseInfo.Version); err != nil {
-		return nil, err
-	} else if latestVersion.GreaterThan(version) {
+	} else if semver.IsUpgradable(config.Version, releaseInfo.Version) {
 		return &releaseInfo.Version, nil
 	} else {
 		return nil, nil

--- a/internal/semver/compare.go
+++ b/internal/semver/compare.go
@@ -1,0 +1,52 @@
+package semver
+
+import (
+	"strconv"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+// isUpgradable checks if latest is greater than installed, according to semver.
+// As a fallback if either cannot be parsed as semver, it returns whether they are different.
+// Am important deviation from the semver standard is that this function DOES try to interpret
+// the version metadata as a number when comparing.
+func IsUpgradable(installed, latest string) bool {
+	var parsedInstalled, parsedLatest *semver.Version
+	var err error
+	if parsedInstalled, err = semver.NewVersion(installed); err != nil {
+		parsedInstalled = nil
+	} else if parsedLatest, err = semver.NewVersion(latest); err != nil {
+		parsedLatest = nil
+	}
+	if parsedLatest != nil && parsedInstalled != nil {
+		if parsedLatest.GreaterThan(parsedInstalled) {
+			return true
+		}
+		return isUpgradableMetadata(parsedInstalled, parsedLatest)
+	} else {
+		return installed != latest
+	}
+}
+
+func isUpgradableMetadata(installed, latest *semver.Version) bool {
+	latestMeta := latest.Metadata()
+	installedMeta := installed.Metadata()
+
+	if latestMeta == installedMeta {
+		return false
+	}
+
+	if latestMeta == "" {
+		return false
+	} else if installedMeta == "" {
+		return true
+	}
+
+	if latestMetaInt, err := strconv.Atoi(latestMeta); err != nil {
+		return installedMeta != latestMeta
+	} else if installedMetaInt, err := strconv.Atoi(installedMeta); err != nil {
+		return installedMeta != latestMeta
+	} else {
+		return installedMetaInt < latestMetaInt
+	}
+}

--- a/internal/semver/compare_test.go
+++ b/internal/semver/compare_test.go
@@ -1,0 +1,64 @@
+package semver
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("IsUpgradable", func() {
+	// testCases is a map of installed version to latest version to expected result
+	testCases := map[string]map[string]bool{
+		"v1.0.0": {
+			"v1.0.0":        false,
+			"v1.0.0+1":      true,
+			"v1.0.0+a":      true,
+			"not a version": true,
+		},
+		"v1.0.0+1": {
+			"v1.0.0":        false,
+			"v1.0.0+1":      false,
+			"v1.0.0+2":      true,
+			"v1.0.0+a":      true,
+			"not a version": true,
+		},
+		"v1.0.0+a": {
+			"v1.0.0":        false,
+			"v1.0.0+1":      true,
+			"v1.0.0+a":      false,
+			"v1.0.0+b":      true,
+			"not a version": true,
+		},
+		"v1.0.0+b": {
+			"v1.0.0":        false,
+			"v1.0.0+1":      true,
+			"v1.0.0+a":      true,
+			"v1.0.0+b":      false,
+			"not a version": true,
+		},
+		"not a version": {
+			"v1.0.0":        true,
+			"v1.0.0+1":      true,
+			"v1.0.0+a":      true,
+			"v1.0.0+b":      true,
+			"not a version": false,
+		},
+	}
+
+	for i, v := range testCases {
+		// save loop variables locally, this is no longer needed after Go 1.22.0
+		installed := i
+		When(fmt.Sprintf("installed is %v", installed), func() {
+			for l, e := range v {
+				latest := l
+				expected := e
+				When(fmt.Sprintf("latest is %v", latest), func() {
+					It(fmt.Sprintf("should return %v", expected), func() {
+						Expect(IsUpgradable(installed, latest)).To(Equal(expected))
+					})
+				})
+			}
+		})
+	}
+})

--- a/internal/semver/semver_suite_test.go
+++ b/internal/semver/semver_suite_test.go
@@ -1,0 +1,13 @@
+package semver
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSemver(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Semver Suite")
+}


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #397 <!-- Issue # here -->

## 📑 Description
With this PR, the build metadata field of the semver is also considered when we check if a version can be upgraded. For this I defined the following rules:

* installed and latest have same metadata (empty or not) -> false
* installed has metadata and latest has no metadata -> false
* installed has no metadata and latest has metadata -> true
* installed and latest have a number as metadata -> installed < latest
* installed and latest have metadata but either is not a number -> installed != latest

Whether we want to allow metadata values that are not integers is of course up for debate, but at least the behavior in such a case is now defined.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->