### PR TITLE
fix(package-operator): add missing permissions for webhook-cert

### DIFF
--- a/config/webhook-cert/rbac.yaml
+++ b/config/webhook-cert/rbac.yaml
@@ -23,6 +23,7 @@ rules:
     resources:
       - secrets
     verbs:
+      - create
       - patch
 
 ---


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->


## 📑 Description
This PR adds the permission to create secrets in the glasskube-system namespace for the webhook cert manager.
<!-- Add a brief description of the pr -->

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->