### PR TITLE
chore: remove redundant image in manager kustomization

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,6 +1,2 @@
 resources:
   - manager.yaml
-images:
-  - name: controller
-    newName: ghcr.io/glasskube/package-operator
-    newTag: v0.0.4 # x-release-please-version


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->


## 📑 Description
The image declaration has been moved to `config/default`, but it is still in ` config/manager`, probably due to an error when resolving merge conflicts.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->