### PR TITLE
fix(ui): make the whole card on package list clickable

### DIFF
--- a/internal/web/templates/components/pkg-overview-btn.html
+++ b/internal/web/templates/components/pkg-overview-btn.html
@@ -16,9 +16,9 @@
     {{ else if eq .Status.Status "Pending" }}
       <button type="button" class="btn btn-primary btn-sm fw-medium w-100" disabled>Pending</button>
     {{ else if eq .Status.Status "Failed" }}
-      <a href="/packages/{{ .PackageName }}" hx-boost="true" class="btn btn-danger btn-sm w-100">
+      <div class="btn btn-danger btn-sm w-100">
         <span>Installation Failed</span>
-      </a>
+      </div>
     {{ else if .UpdateAvailable }}
       <button
         hx-get="/packages/update/modal"
@@ -43,10 +43,10 @@
         <span>Open</span>
       </button>
     {{ else }}
-      <a href="/packages/{{ .PackageName }}" hx-boost="true" class="btn btn-success btn-sm w-100">
+      <div class="btn btn-success btn-sm w-100">
         <i class="bi bi-check-lg"></i>
         <span>Installed</span>
-      </a>
+      </div>
     {{ end }}
   </span>
 {{ end }}

--- a/internal/web/templates/pages/packages.html
+++ b/internal/web/templates/pages/packages.html
@@ -10,38 +10,38 @@
       {{ range .Packages }}
         <div class="col">
           <div class="card bg-body-secondary h-100 border-primary border-1">
-            <div class="card-body p-1 d-flex flex-column gap-1">
-              <div hx-boost="true" class="flex-grow-1 d-flex align-items-center gap-1">
+            <div class="card-body d-flex flex-column p-0">
+              <a
+                class="flex-grow-1 d-flex align-items-center gap-1 text-reset text-decoration-none p-1"
+                href="/packages/{{ .Name }}"
+                hx-boost="true">
                 <div class="flex-shrink-0 align-self-center">
-                  <a class="text-decoration-none" href="/packages/{{ .Name }}">
-                    {{ if eq .IconUrl "" }}
-                      <!-- TODO the glasskube logo as fallback is probably not the best idea? -->
-                      <img
-                        src="/static/assets/glasskube-logo.svg"
-                        alt="{{ .Name }}"
-                        style="width: 3.25rem; height:auto" />
-                    {{ else }}
-                      <img src="{{ .IconUrl }}" alt="{{ .Name }}" style="width: 3.25rem; height:auto" />
-                    {{ end }}
-                  </a>
+                  {{ if eq .IconUrl "" }}
+                    <!-- TODO the glasskube logo as fallback is probably not the best idea? -->
+                    <img
+                      src="/static/assets/glasskube-logo.svg"
+                      alt="{{ .Name }}"
+                      style="width: 3.25rem; height: auto;" />
+                  {{ else }}
+                    <img src="{{ .IconUrl }}" alt="{{ .Name }}" style="width: 3.25rem; height: auto;" />
+                  {{ end }}
                 </div>
                 <div class="flex-grow-1 align-self-start">
-                  <a class="text-reset text-decoration-none" href="/packages/{{ .Name }}">
-                    <h6 class="text-reset m-0">{{ .Name }}</h6>
-                    <span
-                      class="lh-sm overflow-hidden"
-                      style="
+                  <h6 class="text-reset m-0">{{ .Name }}</h6>
+                  <span
+                    class="lh-sm overflow-hidden"
+                    style="
                         font-size: small;
                         display: -webkit-box;
                         -webkit-box-orient: vertical;
-                        -webkit-line-clamp: 2">
-                      {{ .ShortDescription }}
-                    </span>
-                  </a>
+                        -webkit-line-clamp: 2;">
+                    {{ .ShortDescription }}
+                  </span>
                 </div>
+              </a>
+              <div class="mb-1 mx-1">
+                {{ template "pkg-overview-btn" ForPkgOverviewBtn . (index $.PackageUpdateAvailable .Name) }}
               </div>
-
-              {{ template "pkg-overview-btn" ForPkgOverviewBtn . (index $.PackageUpdateAvailable .Name) }}
             </div>
           </div>
         </div>


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->


## 📑 Description
<!-- Add a brief description of the pr -->
I noticed that only the texts and buttons on the package list are actual links. With this PR, the entire card surface becomes clickable.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->