### PR TITLE
chore(ui): remove unnecessary htmx swap attributes

### DIFF
--- a/internal/web/components/pkg_detail_btns/controller.go
+++ b/internal/web/components/pkg_detail_btns/controller.go
@@ -13,7 +13,6 @@ const TemplateId = "pkg-detail-btns"
 
 type pkgDetailBtnsInput struct {
 	ContainerId     string
-	Swap            string
 	PackageName     string
 	Status          *client.PackageStatus
 	Manifest        *v1alpha1.PackageManifest
@@ -24,15 +23,10 @@ func getId(pkgName string) string {
 	return fmt.Sprintf("%v-%v", TemplateId, pkgName)
 }
 
-func getSwap(id string) string {
-	return fmt.Sprintf("outerHTML:#%s", id)
-}
-
 func Render(w io.Writer, tmpl *template.Template, pkg *v1alpha1.Package, status *client.PackageStatus, manifest *v1alpha1.PackageManifest, updateAvailable bool) error {
 	id := getId(pkg.Name)
 	return tmpl.ExecuteTemplate(w, TemplateId, &pkgDetailBtnsInput{
 		ContainerId:     id,
-		Swap:            getSwap(id),
 		PackageName:     pkg.Name,
 		Status:          status,
 		Manifest:        manifest,
@@ -50,7 +44,6 @@ func ForPkgDetailBtns(
 	id := getId(pkgName)
 	return &pkgDetailBtnsInput{
 		ContainerId:     id,
-		Swap:            "",
 		PackageName:     pkgName,
 		Status:          status,
 		Manifest:        manifest,

--- a/internal/web/components/pkg_overview_btn/controller.go
+++ b/internal/web/components/pkg_overview_btn/controller.go
@@ -14,7 +14,6 @@ const TemplateId = "pkg-overview-btn"
 
 type pkgOverviewBtnInput struct {
 	ButtonId        string
-	Swap            string
 	PackageName     string
 	Status          *client.PackageStatus
 	Manifest        *v1alpha1.PackageManifest
@@ -29,7 +28,6 @@ func Render(w io.Writer, tmpl *template.Template, pkg *v1alpha1.Package, status 
 	buttonId := getButtonId(pkg.Name)
 	return tmpl.ExecuteTemplate(w, TemplateId, &pkgOverviewBtnInput{
 		ButtonId:        buttonId,
-		Swap:            fmt.Sprintf("outerHTML:#%s", buttonId),
 		PackageName:     pkg.Name,
 		Status:          status,
 		Manifest:        manifest,
@@ -41,7 +39,6 @@ func ForPkgOverviewBtn(packageWithStatus *list.PackageWithStatus, updateAvailabl
 	buttonId := getButtonId(packageWithStatus.Name)
 	return &pkgOverviewBtnInput{
 		ButtonId:        buttonId,
-		Swap:            "",
 		PackageName:     packageWithStatus.Name,
 		Status:          packageWithStatus.Status,
 		Manifest:        packageWithStatus.InstalledManifest,

--- a/internal/web/templates/components/pkg-detail-btns.html
+++ b/internal/web/templates/components/pkg-detail-btns.html
@@ -28,7 +28,7 @@
 
 {{ define "pkg-detail-btns" }}
 
-  <span id="{{ .ContainerId }}" hx-swap-oob="{{ .Swap }}" hx-swap="none">
+  <span id="{{ .ContainerId }}" hx-swap="none">
     {{ if eq .Status nil }}
       <button
         hx-get="/packages/install/modal"

--- a/internal/web/templates/components/pkg-overview-btn.html
+++ b/internal/web/templates/components/pkg-overview-btn.html
@@ -1,5 +1,5 @@
 {{ define "pkg-overview-btn" }}
-  <span id="{{ .ButtonId }}" hx-swap-oob="{{ .Swap }}">
+  <span id="{{ .ButtonId }}">
     {{ if eq .Status nil }}
       <button
         hx-get="/packages/install/modal"


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->


## 📑 Description
<!-- Add a brief description of the pr -->
Swapping the overview and detail buttons also works without the swap attribute, this seems to be considered by default when sending its sent via websocket by htmx.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
