### PR TITLE
feat(ui): introduce global error handling

### DIFF
--- a/internal/web/components/alert/controller.go
+++ b/internal/web/components/alert/controller.go
@@ -1,0 +1,13 @@
+package alert
+
+type alertInput struct {
+	Message     string
+	Dismissible bool
+}
+
+func ForAlert(err error) alertInput {
+	return alertInput{
+		Message:     err.Error(),
+		Dismissible: false,
+	}
+}

--- a/internal/web/templates.go
+++ b/internal/web/templates.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path"
 
+	"github.com/glasskube/glasskube/internal/web/components/alert"
+
 	"github.com/glasskube/glasskube/api/v1alpha1"
 
 	"github.com/glasskube/glasskube/internal/repo"
@@ -27,6 +29,7 @@ var (
 	pkgInstallModalTmpl *template.Template
 	pkgUpdateModalTmpl  *template.Template
 	pkgUpdateAlertTmpl  *template.Template
+	alertTmpl           *template.Template
 	templatesDir        = "templates"
 	componentsDir       = path.Join(templatesDir, "components")
 	pagesDir            = path.Join(templatesDir, "pages")
@@ -50,6 +53,7 @@ func init() {
 				return url
 			}
 		},
+		"ForAlert": alert.ForAlert,
 	}
 	baseTemplate = template.Must(template.New("base.html").
 		Funcs(templateFuncs).
@@ -64,6 +68,7 @@ func init() {
 	pkgUpdateAlertTmpl = componentTmpl(pkg_update_alert.TemplateId, "pkg-update-alert.html")
 	pkgInstallModalTmpl = componentTmpl("pkg-install-modal", "pkg-install-modal.html")
 	pkgUpdateModalTmpl = componentTmpl("pkg-update-modal", "pkg-update-modal.html")
+	alertTmpl = componentTmpl("alert", "alert.html")
 }
 
 func pageTmpl(fileName string) *template.Template {

--- a/internal/web/templates/components/alert.html
+++ b/internal/web/templates/components/alert.html
@@ -1,0 +1,8 @@
+{{ define "alert" }}
+  <div class="alert alert-danger alert-dismissible" role="alert">
+    <div>{{ .Message }}</div>
+    {{ if .Dismissible }}
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    {{ end }}
+  </div>
+{{ end }}

--- a/internal/web/templates/components/pkg-overview-btn.html
+++ b/internal/web/templates/components/pkg-overview-btn.html
@@ -36,8 +36,7 @@
       <button
         class="btn btn-success btn-sm w-100"
         hx-post="/packages/open"
-        hx-swap="innerHTML"
-        hx-target="#error-container"
+        hx-swap="none"
         name="packageName"
         value="{{ .PackageName }}">
         <i class="bi bi-box-arrow-up-right"></i>

--- a/internal/web/templates/layout/base.html
+++ b/internal/web/templates/layout/base.html
@@ -10,7 +10,7 @@
     </script>
   </head>
 
-  <body hx-ext="ws" ws-connect="/ws" hx-indicator="#indicator">
+  <body hx-ext="ws,response-targets" ws-connect="/ws" hx-indicator="#indicator" hx-target-error="#error-container">
     <nav hx-boost="true" class="navbar navbar-expand-lg navbar-dark bg-secondary">
       <div id="indicator" class="progress-container bg-transparent w-100 position-fixed top-0 start-0">
         <div class="htmx-indicator progress-bar bg-primary h-100 w-100"></div>
@@ -52,27 +52,23 @@
       </div>
     </nav>
 
-    <div id="ws-error-container" class="visually-hidden container-lg mt-2">
-      <div class="alert alert-danger" role="alert" id="ws-error-container-message"></div>
-    </div>
-
-    <div id="error-container" class="container-lg mt-2"></div>
-
     <main id="main">
+      <div id="ws-error-container" class="visually-hidden container-lg mt-2">
+        <div class="alert alert-danger" role="alert" id="ws-error-container-message"></div>
+      </div>
+
+      <div id="error-container" class="container-lg mt-2">
+        {{ if .Error }}
+          {{ template "alert" .Error | ForAlert }}
+        {{ end }}
+      </div>
+
       {{ template "body" . }}
     </main>
 
     <div class="modal" id="modal-container" tabindex="-1" style="display: none" aria-hidden="false">
       <div class="modal-dialog" role="document"></div>
     </div>
-    <script>
-      document.addEventListener('htmx:responseError', function (event) {
-        const xhr = event.detail.xhr;
-        if (xhr && xhr.status === 400 && xhr.responseText) {
-          document.getElementById('error-container').innerHTML = xhr.responseText;
-        }
-      });
-    </script>
     <script>
       (() => {
         const getColorSchemeQuery = () => window.matchMedia('(prefers-color-scheme: dark)');

--- a/internal/web/templates/pages/package.html
+++ b/internal/web/templates/pages/package.html
@@ -1,93 +1,95 @@
 {{ define "body" }}
-  <div
-    class="container-lg mt-2"
-    hx-trigger="htmx:historyRestore from:body"
-    hx-get="/packages/{{ .Manifest.Name }}"
-    hx-select="main"
-    hx-target="main">
-    <div class="row p-3 col-lg-10 offset-lg-1">
-      <div class="d-flex flex-column">
-        <div class="d-flex align-items-center">
-          <div class="flex-shrink-0 ps-1 pe-2 py-1 align-self-center">
-            {{ if eq .Manifest.IconUrl "" }}
-              <!-- TODO the glasskube logo as fallback is probably not the best idea? -->
-              <img
-                src="/static/assets/glasskube-logo.svg"
-                alt="{{ .Manifest.Name }}"
-                style="width: 8rem; height:auto" />
-            {{ else }}
-              <img src="{{ .Manifest.IconUrl }}" alt="{{ .Manifest.Name }}" style="width: 8rem; height:auto" />
-            {{ end }}
-
-          </div>
-          <div class="flex-grow-1 ps-0 pe-1 py-1">
-            <div class="mb-2">
-              <span class="d-flex ">
-                <h1 class="text-reset d-inline-flex flex-grow-1 m-0">
-                  {{ .Manifest.Name }}
-                </h1>
-                <span class="align-self-center mx-auto">
-                  {{ template "pkg-detail-btns" ForPkgDetailBtns .Manifest.Name .Status .Manifest .Package .UpdateAvailable }}
-                </span>
-              </span>
-            </div>
-            <span class="lh-sm">
-              {{ .Manifest.ShortDescription }}
-            </span>
-            <div class="mt-2">
-              <a
-                class="icon-link text-reset me-2"
-                href="{{ PackageManifestUrl .Manifest.Name .Package .LatestVersion }}"
-                target="_blank">
-                <span class="bi bi-box-arrow-up-right"></span>
-                Glasskube Package Manifest
-              </a>
-              {{ range .Manifest.References }}
-                <a class="icon-link text-reset me-2" href="{{ .Url }}" target="_blank">
-                  <span class="bi bi-box-arrow-up-right"></span>
-                  {{ .Label }}
-                </a>
+  {{ if .Manifest }}
+    <div
+      class="container-lg mt-2"
+      hx-trigger="htmx:historyRestore from:body"
+      hx-get="/packages/{{ .Manifest.Name }}"
+      hx-select="main"
+      hx-target="main">
+      <div class="row p-3 col-lg-10 offset-lg-1">
+        <div class="d-flex flex-column">
+          <div class="d-flex align-items-center">
+            <div class="flex-shrink-0 ps-1 pe-2 py-1 align-self-center">
+              {{ if eq .Manifest.IconUrl "" }}
+                <!-- TODO the glasskube logo as fallback is probably not the best idea? -->
+                <img
+                  src="/static/assets/glasskube-logo.svg"
+                  alt="{{ .Manifest.Name }}"
+                  style="width: 8rem; height:auto" />
+              {{ else }}
+                <img src="{{ .Manifest.IconUrl }}" alt="{{ .Manifest.Name }}" style="width: 8rem; height:auto" />
               {{ end }}
+
+            </div>
+            <div class="flex-grow-1 ps-0 pe-1 py-1">
+              <div class="mb-2">
+                <span class="d-flex ">
+                  <h1 class="text-reset d-inline-flex flex-grow-1 m-0">
+                    {{ .Manifest.Name }}
+                  </h1>
+                  <span class="align-self-center mx-auto">
+                    {{ template "pkg-detail-btns" ForPkgDetailBtns .Manifest.Name .Status .Manifest .Package .UpdateAvailable }}
+                  </span>
+                </span>
+              </div>
+              <span class="lh-sm">
+                {{ .Manifest.ShortDescription }}
+              </span>
+              <div class="mt-2">
+                <a
+                  class="icon-link text-reset me-2"
+                  href="{{ PackageManifestUrl .Manifest.Name .Package .LatestVersion }}"
+                  target="_blank">
+                  <span class="bi bi-box-arrow-up-right"></span>
+                  Glasskube Package Manifest
+                </a>
+                {{ range .Manifest.References }}
+                  <a class="icon-link text-reset me-2" href="{{ .Url }}" target="_blank">
+                    <span class="bi bi-box-arrow-up-right"></span>
+                    {{ .Label }}
+                  </a>
+                {{ end }}
+              </div>
             </div>
           </div>
         </div>
-      </div>
 
-      <div class="mt-3">
-        <h2 class="text-reset">Package Details</h2>
-
-        <span>
-          {{ if eq .Manifest.LongDescription "" }}
-            <i
-              >This package has no detailed description yet. You can request to change this here:
-              <a
-                class="icon-link text-reset me-2"
-                href="{{ PackageManifestUrl .Manifest.Name .Package .LatestVersion }}"
-                target="_blank">
-                <span class="bi bi-box-arrow-up-right"></span>
-                Glasskube Package Manifest
-              </a>
-            </i>
-          {{ else }}
-            {{ .Manifest.LongDescription }}
-          {{ end }}
-        </span>
-      </div>
-
-      {{ if ne .Manifest.Dependencies nil }}
         <div class="mt-3">
-          <h2 class="text-reset">Package Dependencies</h2>
+          <h2 class="text-reset">Package Details</h2>
 
-          <ul>
-            {{ range .Manifest.Dependencies }}
-              <li>
-                <a class="text-reset" hx-boost="true" href="/packages/{{ .Name }}">{{ .Name }}</a>
-                {{ if ne .Version "" }}({{ .Version }}){{ end }}
-              </li>
+          <span>
+            {{ if eq .Manifest.LongDescription "" }}
+              <i
+                >This package has no detailed description yet. You can request to change this here:
+                <a
+                  class="icon-link text-reset me-2"
+                  href="{{ PackageManifestUrl .Manifest.Name .Package .LatestVersion }}"
+                  target="_blank">
+                  <span class="bi bi-box-arrow-up-right"></span>
+                  Glasskube Package Manifest
+                </a>
+              </i>
+            {{ else }}
+              {{ .Manifest.LongDescription }}
             {{ end }}
-          </ul>
+          </span>
         </div>
-      {{ end }}
+
+        {{ if ne .Manifest.Dependencies nil }}
+          <div class="mt-3">
+            <h2 class="text-reset">Package Dependencies</h2>
+
+            <ul>
+              {{ range .Manifest.Dependencies }}
+                <li>
+                  <a class="text-reset" hx-boost="true" href="/packages/{{ .Name }}">{{ .Name }}</a>
+                  {{ if ne .Version "" }}({{ .Version }}){{ end }}
+                </li>
+              {{ end }}
+            </ul>
+          </div>
+        {{ end }}
+      </div>
     </div>
-  </div>
+  {{ end }}
 {{ end }}

--- a/web/index.js
+++ b/web/index.js
@@ -1,4 +1,5 @@
 import 'htmx.org';
 import './windowHtmx';
 import 'htmx.org/dist/ext/ws';
+import 'htmx.org/dist/ext/response-targets';
 import 'bootstrap';


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->

## 📑 Description

Accidently messed up #420 

Made error handling a bit more reusable by introducing a util function on the server, which renders an html template. This template is sent together with two HTMX response headers.
This should be re-usable everywhere in the application because the response headers overwrite any client-side `hx-select` / `hx-swap` attributes in case of an error. 
The htmx extension [response-targets](https://htmx.org/extensions/response-targets/) does the swapping clientside. 

There is also the possibility now to show server-side errors on a page template, e.g. when loading the packages page errors for some reason. 

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->