### PR TITLE
fix(ui, cli): prevent a panic if a package has no OwnedPackageInfo (#419)

### DIFF
--- a/pkg/list/list.go
+++ b/pkg/list/list.go
@@ -120,11 +120,14 @@ func fetchRepoAndInstalled(pkgClient client.PackageV1Alpha1Client, ctx context.C
 		for j, clusterPackage := range packages.Items {
 			if indexPackage.Name == clusterPackage.Name {
 				result[i].Package = &packages.Items[j]
-				for k, packageInfo := range packageInfos.Items {
+				if len(clusterPackage.Status.OwnedPackageInfos) > 0 {
+					// TODO: It would be better to use .Spec.PackageInfo to get the name of the correct PackageInfo
 					packageInfoName := clusterPackage.Status.OwnedPackageInfos[len(clusterPackage.Status.OwnedPackageInfos)-1].Name
-					if packageInfo.Name == packageInfoName {
-						result[i].PackageInfo = &packageInfos.Items[k]
-						break
+					for k, packageInfo := range packageInfos.Items {
+						if packageInfo.Name == packageInfoName {
+							result[i].PackageInfo = &packageInfos.Items[k]
+							break
+						}
 					}
 				}
 				break


### PR DESCRIPTION


<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #419 <!-- Issue # here -->

## 📑 Description
See issue details for info on the bug

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->