### PR TITLE
fix(ui): parse templates before starting informer to avoid panic

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -143,17 +143,16 @@ func (s *server) Start(ctx context.Context) error {
 		return errors.New("server is already listening")
 	}
 
-	_ = s.initKubeConfig()
-	if err := s.checkBootstrapped(ctx); err == nil {
-		s.startInformer(ctx)
-	}
-
+	parseTemplates()
 	if config.IsDevBuild() {
 		if err := watchTemplates(); err != nil {
 			fmt.Fprintf(os.Stderr, "templates will not be parsed after changes: %v\n", err)
 		}
 	}
-	parseTemplates()
+	_ = s.initKubeConfig()
+	if err := s.checkBootstrapped(ctx); err == nil {
+		s.startInformer(ctx)
+	}
 
 	root, err := fs.Sub(webFs, "root")
 	if err != nil {


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->


## 📑 Description
<!-- Add a brief description of the pr -->

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->