### PR TITLE
fix(cli, ui): bootstrap handles nil values in `checkWorkloadReady` and major speedup

### DIFF
--- a/internal/clientutils/resources.go
+++ b/internal/clientutils/resources.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
-func FetchResources(url string) (*[]unstructured.Unstructured, error) {
+func FetchResources(url string) ([]unstructured.Unstructured, error) {
 	response, err := http.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("could not download manifest %v: %w", url, err)
@@ -29,5 +29,5 @@ func FetchResources(url string) (*[]unstructured.Unstructured, error) {
 		}
 		resources = append(resources, object)
 	}
-	return &resources, nil
+	return resources, nil
 }

--- a/internal/manifest/plain/adapter.go
+++ b/internal/manifest/plain/adapter.go
@@ -74,9 +74,9 @@ func (r *Adapter) reconcilePlainManifest(
 		return nil, err
 	} else {
 		// Unstructured implements client.Object but we need it as a reference so the interface is fulfilled.
-		objectsToApply = make([]client.Object, len(*unstructured))
-		for i := range *unstructured {
-			objectsToApply[i] = &(*unstructured)[i]
+		objectsToApply = make([]client.Object, len(unstructured))
+		for i := range unstructured {
+			objectsToApply[i] = &unstructured[i]
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #464  <!-- Issue # here -->

## 📑 Description
This PR fixes several problems of the BootstrapClient:
- not handling `nil` correctly when checking deployment status (which lead to the bug in #464)
- it creates and checks resources in order, which is now sped up significantly by applying all, then checking them in sequence
- ignoring apply error
- using timer instead of ticker when checking deployment status

In addition to the above, bootstrap now also prints how long it took :slightly_smiling_face: 

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->