### PR TITLE
feat(cli): should not show latest version if installed version is newer

### DIFF
--- a/cmd/glasskube/cmd/list.go
+++ b/cmd/glasskube/cmd/list.go
@@ -130,7 +130,7 @@ func versionString(pkg list.PackageWithStatus) string {
 			if statusVersion != specVersion {
 				versionAddons = append(versionAddons, fmt.Sprintf("%v desired", specVersion))
 			}
-			if repoVersion != "" && semver.IsUpgradable(statusVersion, repoVersion) && statusVersion != repoVersion {
+			if repoVersion != "" && semver.IsUpgradable(statusVersion, repoVersion) {
 				versionAddons = append(versionAddons, fmt.Sprintf("%v available", repoVersion))
 			}
 			if len(versionAddons) > 0 {

--- a/cmd/glasskube/cmd/list.go
+++ b/cmd/glasskube/cmd/list.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/glasskube/glasskube/api/v1alpha1"
 	"github.com/glasskube/glasskube/internal/cliutils"
+	"github.com/glasskube/glasskube/internal/semver"
 	"github.com/glasskube/glasskube/pkg/client"
 	"github.com/glasskube/glasskube/pkg/list"
 	"github.com/spf13/cobra"
@@ -129,7 +130,7 @@ func versionString(pkg list.PackageWithStatus) string {
 			if statusVersion != specVersion {
 				versionAddons = append(versionAddons, fmt.Sprintf("%v desired", specVersion))
 			}
-			if repoVersion != "" && statusVersion != repoVersion {
+			if repoVersion != "" && !semver.IsUpgradable(repoVersion, statusVersion) && statusVersion != repoVersion {
 				versionAddons = append(versionAddons, fmt.Sprintf("%v available", repoVersion))
 			}
 			if len(versionAddons) > 0 {

--- a/cmd/glasskube/cmd/list.go
+++ b/cmd/glasskube/cmd/list.go
@@ -130,7 +130,7 @@ func versionString(pkg list.PackageWithStatus) string {
 			if statusVersion != specVersion {
 				versionAddons = append(versionAddons, fmt.Sprintf("%v desired", specVersion))
 			}
-			if repoVersion != "" && !semver.IsUpgradable(repoVersion, statusVersion) && statusVersion != repoVersion {
+			if repoVersion != "" && semver.IsUpgradable(statusVersion, repoVersion) && statusVersion != repoVersion {
 				versionAddons = append(versionAddons, fmt.Sprintf("%v available", repoVersion))
 			}
 			if len(versionAddons) > 0 {


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #441
Fixes #441

## 📑 Description
`glasskube ls` should not show latest available version if installed version is newer than latest version
This is how the terminal looks like now.
Notice here the argo-cd package is installed on the pre-release version.
```
PS H:\glasskube> .\main.exe ls   
NAME                  STATUS         VERSION                                  AUTO-UPDATE
argo-cd               Ready          v2.10.5+1
cert-manager          Ready          v1.14.2+1
cyclops               Not installed
ingress-nginx         Not installed
keptn                 Ready          v2.0.0-rc.1+1 (v2.0.0-rc.2+1 available)
kubernetes-dashboard  Ready          v2.7.0+1 (v2.7.0+2 available)
```
## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->