### PR TITLE
fix(package-operator): don't skip update validation if values changed

### DIFF
--- a/internal/webhook/package_validator.go
+++ b/internal/webhook/package_validator.go
@@ -3,6 +3,7 @@ package webhook
 import (
 	"context"
 	"errors"
+	"reflect"
 
 	"github.com/glasskube/glasskube/api/v1alpha1"
 	ctrladapter "github.com/glasskube/glasskube/internal/adapter/controllerruntime"
@@ -56,11 +57,11 @@ func (p *PackageValidatingWebhook) ValidateUpdate(ctx context.Context, oldObj ru
 	log := ctrl.LoggerFrom(ctx)
 	if oldPkg, ok := oldObj.(*v1alpha1.Package); ok {
 		if newPkg, ok := newObj.(*v1alpha1.Package); ok {
-			if oldPkg.Spec.PackageInfo == newPkg.Spec.PackageInfo {
+			log.Info("validate update", "name", newPkg.Name)
+			if reflect.DeepEqual(oldPkg.Spec, newPkg.Spec) {
 				// If the package info did not change, we are already done
 				return nil, nil
 			} else {
-				log.Info("validate update", "name", newPkg.Name)
 				return nil, p.validateCreateOrUpdate(ctx, newPkg)
 			}
 		}


### PR DESCRIPTION
## 📑 Description
Currently, the validating webhook erroneously skips validation for updates if the `.Spec.PackageInfo` did not change. This is no longer correct since we now have more spec items than that.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->