### PR TITLE
fix: always try to resolve all values to improve error message

### DIFF
--- a/internal/manifestvalues/resolver.go
+++ b/internal/manifestvalues/resolver.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/glasskube/glasskube/api/v1alpha1"
 	"github.com/glasskube/glasskube/internal/adapter"
+	"go.uber.org/multierr"
 )
 
 type Resolver struct {
@@ -23,15 +24,16 @@ func (r *Resolver) Resolve(ctx context.Context, values map[string]v1alpha1.Value
 	map[string]string,
 	error,
 ) {
+	var errComposite error
 	resolvedValues := make(map[string]string)
 	for name, value := range values {
 		if resolved, err := r.ResolveValue(ctx, value); err != nil {
-			return nil, fmt.Errorf("cannot resolve value %v: %w", name, err)
+			multierr.AppendInto(&errComposite, fmt.Errorf("cannot resolve value %v: %w", name, err))
 		} else {
 			resolvedValues[name] = resolved
 		}
 	}
-	return resolvedValues, nil
+	return resolvedValues, errComposite
 }
 
 func (r *Resolver) ResolveValue(ctx context.Context, value v1alpha1.ValueConfiguration) (string, error) {


### PR DESCRIPTION
## 📑 Description
Currently, if an error is encountered during config value resolution, it is returned. With this change, all errors are resolved and a multi error is returned so that a user can always know all the values that can not be resolved

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
This came up in https://github.com/glasskube/glasskube/pull/479#discussion_r1560936268