### PR TITLE
fix(ui): add hx-boost to fix inconsistent browser back/forth

### DIFF
--- a/internal/web/templates/components/pkg-overview-btn.html
+++ b/internal/web/templates/components/pkg-overview-btn.html
@@ -1,7 +1,9 @@
 {{ define "pkg-overview-btn" }}
   <span id="{{ .ButtonId }}">
     {{ if eq .Status nil }}
-      <a href="/packages/{{ .PackageName }}#configuration" class="btn btn-primary btn-sm w-100">Install</a>
+      <a href="/packages/{{ .PackageName }}#configuration" hx-boost="true" class="btn btn-primary btn-sm w-100"
+        >Install</a
+      >
     {{ else if eq .Status.Status "Pending" }}
       <button type="button" class="btn btn-primary btn-sm fw-medium w-100" disabled>Pending</button>
     {{ else if eq .Status.Status "Failed" }}


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->

## 📑 Description
When clicking the Install button from the packages overview page, then installing the opened package, and navigating back to the overview page with the browser back button, the page was not refreshed correctly. Cause was that the link to the package detail page did not have the `hx-boost=true` flag, which made it load the complete page. It seems that then the `htmx:historyRestore` used to reload the page contents when going back, does not work correctly. 

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->