### PR TITLE
fix(package-operator): prevent reconcile loop on packageinfo error

### DIFF
--- a/internal/controller/packageinfo_controller.go
+++ b/internal/controller/packageinfo_controller.go
@@ -71,11 +71,6 @@ func (r *PackageInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	if shouldSyncFromRepo(packageInfo) {
-		if err := conditions.SetUnknownAndUpdate(ctx, r.Client, &packageInfo, &packageInfo.Status.Conditions,
-			condition.Pending, "Updating manifest"); err != nil {
-			return requeue.Always(ctx, err)
-		}
-
 		log.Info("updating manifest")
 		if err := updatePackageManifest(&packageInfo); err != nil {
 			err1 := conditions.SetFailedAndUpdate(ctx, r.Client, r.EventRecorder, &packageInfo, &packageInfo.Status.Conditions,


### PR DESCRIPTION
## 📑 Description
This PR fixes a bug that exists since a long time. If there is an error during the PackageInfo reconciliation, the operator could enter a state where it would repeatedly reconcile the related Package and PackageInfo over and over again. By not setting the "updating manifest" condition on the PackageInfo, this no longer happens, because in case the error happens again, no resource update is needed. Normal exponential backoff still applies.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->