### PR TITLE
fix(ui): restructure server initializations

### DIFF
--- a/pkg/client/package_cache.go
+++ b/pkg/client/package_cache.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/glasskube/glasskube/api/v1alpha1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -42,7 +41,7 @@ func (c *chachedPackageClient) Get(ctx context.Context, pkgName string, result *
 	if obj, ok, err := c.store.GetByKey(pkgName); err != nil {
 		return apierrors.NewInternalError(err)
 	} else if !ok {
-		return apierrors.NewNotFound(schema.GroupResource{}, pkgName)
+		return c.PackageInterface.Get(ctx, pkgName, result)
 	} else if pkg, ok := obj.(*v1alpha1.Package); !ok {
 		return apierrors.NewInternalError(errors.New("not a package"))
 	} else {

--- a/pkg/client/packageinfo_cache.go
+++ b/pkg/client/packageinfo_cache.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/glasskube/glasskube/api/v1alpha1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -19,7 +18,7 @@ func (c *cachedPackageInfoClient) Get(ctx context.Context, pkgInfoName string, r
 	if obj, ok, err := c.store.GetByKey(pkgInfoName); err != nil {
 		return apierrors.NewInternalError(err)
 	} else if !ok {
-		return apierrors.NewNotFound(schema.GroupResource{}, pkgInfoName)
+		return c.PackageInfoInterface.Get(ctx, pkgInfoName, result)
 	} else if pkgInfo, ok := obj.(*v1alpha1.PackageInfo); !ok {
 		return apierrors.NewInternalError(errors.New("not a packageinfo"))
 	} else {


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->

## 📑 Description
This PR fixes a performance issue which occurs when at least 4 packages are installed in a cluster + the user switches back and forth between package detail pages very quickly. The cause of this was that the used package client was not actually the cached one, because of the incorrect initialization. 

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->