### PR TITLE
refactor: pkg recoverable condition #60

### DIFF
--- a/pkg/condition/condition.go
+++ b/pkg/condition/condition.go
@@ -21,3 +21,14 @@ const (
 	InstallationFailed        Reason = "InstallationFailed"
 	Pending                   Reason = "Pending"
 )
+
+func (r Reason) Recoverable() bool {
+	switch r {
+	case InstallationFailed:
+		return false
+	case UnsupportedFormat:
+		return false
+	default:
+		return true
+	}
+}


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->
https://github.com/glasskube/glasskube/pull/484

## ✅ Checks
- [✅] make all
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
so what i was thinking , in `internal/controller/package_controller.go`    `PackageReconcilationContext` assuming its giving pkg related info , so what we can do is if we get any error we can read the `PackageReconcilationContext.isRecoverable` whcih is updated by the SetFailed , additionaly for detailed error im not sure how i can add it with `Recoverable` function so if there is any logger in glasskube maybe we can use that for detailed errors.