### PR TITLE
glasskube version show an error when not bootstrapped

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -599,13 +599,22 @@ func (s *server) kubeconfigPage(w http.ResponseWriter, r *http.Request) {
 func (s *server) enrichWithErrorAndWarnings(ctx context.Context, data map[string]any, err error) map[string]any {
 	data["Error"] = err
 	data["CurrentContext"] = s.rawConfig.CurrentContext
-	if operatorVersion, clientVersion, err := s.getGlasskubeVersions(ctx); err != nil {
+	operatorVersion, clientVersion, err := s.getGlasskubeVersions(ctx)
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to check for version mismatch: %v\n", err)
 	} else if operatorVersion != nil && clientVersion != nil && !operatorVersion.Equal(clientVersion) {
-		data["VersionMismatchWarning"] = map[string]any{
+		data["VersionMismatchWarning"] = true
+	}
+	if operatorVersion != nil && clientVersion != nil && !config.IsDevBuild() {
+		data["VersionDetails"] = map[string]any{
 			"OperatorVersion":     operatorVersion.String(),
 			"ClientVersion":       clientVersion.String(),
 			"NeedsOperatorUpdate": operatorVersion.LessThan(clientVersion),
+		}
+	}
+	if config.IsDevBuild() {
+		data["VersionDetails"] = map[string]any{
+			"OperatorVersion": config.Version,
 		}
 	}
 	return data

--- a/internal/web/templates/layout/base.html
+++ b/internal/web/templates/layout/base.html
@@ -50,8 +50,7 @@
           </ul>
         </div>
       </div>
-    </nav>
-
+    </nav>    
     <main id="main">
       <div id="ws-error-container" class="visually-hidden container-lg mt-2">
         <div class="alert alert-danger" role="alert" id="ws-error-container-message"></div>
@@ -62,7 +61,7 @@
           {{ template "alert" .Error "danger" | ForAlert }}
         {{ end }}
         {{ if .VersionMismatchWarning }}
-          {{ template "version-mismatch-warning" .VersionMismatchWarning }}
+          {{ template "version-mismatch-warning" .VersionDetails }}
         {{ end }}
       </div>
 
@@ -98,5 +97,16 @@
         }
       });
     </script>
+    <footer class="footer py-3 position-fixed bottom-0 w-100" style="background-color: #cccccc4a;">
+      <div class="container text-center">
+        <span class="text-muted">Glasskube Version: {{ .VersionDetails.OperatorVersion }}</span>
+        <br>
+        {{ if .VersionDetails.NeedsOperatorUpdate }}
+            <span class="text-danger">New version available! ({{ .VersionDetails.ClientVersion }})</span>
+        {{ else }}
+            <span class="text-success">Up to date</span>
+        {{ end }}
+    </div>
+    </footer>
   </body>
 </html>

--- a/internal/web/templates/layout/base.html
+++ b/internal/web/templates/layout/base.html
@@ -50,7 +50,7 @@
           </ul>
         </div>
       </div>
-    </nav>    
+    </nav>
     <main id="main">
       <div id="ws-error-container" class="visually-hidden container-lg mt-2">
         <div class="alert alert-danger" role="alert" id="ws-error-container-message"></div>
@@ -100,13 +100,13 @@
     <footer class="footer py-3 position-fixed bottom-0 w-100" style="background-color: #cccccc4a;">
       <div class="container text-center">
         <span class="text-muted">Glasskube Version: {{ .VersionDetails.OperatorVersion }}</span>
-        <br>
+        <br />
         {{ if .VersionDetails.NeedsOperatorUpdate }}
-            <span class="text-danger">New version available! ({{ .VersionDetails.ClientVersion }})</span>
+          <span class="text-danger">New version available! ({{ .VersionDetails.ClientVersion }})</span>
         {{ else }}
-            <span class="text-success">Up to date</span>
+          <span class="text-success">Up to date</span>
         {{ end }}
-    </div>
+      </div>
     </footer>
   </body>
 </html>


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes https://github.com/glasskube/glasskube/issues/529

## 📑 Description
<!-- Add a brief description of the pr -->
Changed the error message to show that the glasskube is not bootstrapped yet do it using glasskube bootstrap command.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->