### PR TITLE
docs(website): add star counter, add producthunt banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,16 @@
      <a href="https://x.com/intent/follow?screen_name=glasskube" target="_blank">Twitter / X</a>
   </p>
 </div>
-
+<br>
+<br>
+<div align="center">
+<a href="https://www.producthunt.com/products/glasskube?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-glasskube" target="_blank">
+  <img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=452879&theme=light"
+    alt="Glasskube - &#0032;🧊&#0032;The&#0032;next&#0032;generation&#0032;Package&#0032;Manager&#0032;for&#0032;Kubernetes&#0032;📦 | Product Hunt"
+    style="width: 250px; height: 54px;" width="250" height="54" />
+</a>
+</div>
+<br>
 <hr>
 
 ![Glasskube GUI Mockup](https://github.com/glasskube/operator/assets/3041752/71d0da0c-34ac-40b7-8740-bd2a81ca9f07)

--- a/cmd/glasskube/cmd/root.go
+++ b/cmd/glasskube/cmd/root.go
@@ -21,7 +21,7 @@ var (
 	RootCmd = cobra.Command{
 		Use:     "glasskube",
 		Version: config.Version,
-		Short:   "🧊 The missing Package Manager for Kubernetes 📦",
+		Short:   "🧊 The next generation Package Manager for Kubernetes 📦",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			telemetry.Init()
 			if !rootCmdOptions.SkipUpdateCheck {

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -45,7 +45,7 @@ func DefaultOptions() BootstrapOptions {
 
 const installMessage = `
 ## Installing GLASSKUBE ##
-🧊 The missing Package Manager for Kubernetes 📦`
+🧊 The next generation Package Manager for Kubernetes 📦`
 
 func NewBootstrapClient(config *rest.Config) *BootstrapClient {
 	return &BootstrapClient{clientConfig: config}

--- a/website/blog/2024-02-01-technical-preview/index.mdx
+++ b/website/blog/2024-02-01-technical-preview/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: technical-preview
 title: Glasskube v0.0.1 — Technical Preview
-description: "How to make 6M developers' life easier? Introducing Glasskube—The Missing Package Manager For Kubernetes"
+description: "How to make 6M developers' life easier? Introducing Glasskube—The next generation Package Manager For Kubernetes"
 authors: [ pmig, lw ]
 tags: [ glasskube, release, kubernetes ]
 ---
@@ -13,7 +13,7 @@ import Install from '../../src/partials/_install.mdx';
 
 Glasskube is fully open-source. Support us by leaving a star: [⭐ `glasskube/glasskube` ⭐](https://github.com/glasskube/glasskube/)
 
-## Introducing Glasskube — The Missing Package Manager For Kubernetes
+## Introducing Glasskube — The next generation Package Manager For Kubernetes
 
 ![Glasskube GUI Mockup](https://github.com/glasskube/operator/assets/3041752/71d0da0c-34ac-40b7-8740-bd2a81ca9f07)
 

--- a/website/blog/2024-02-08-cncf-landscape/index.mdx
+++ b/website/blog/2024-02-08-cncf-landscape/index.mdx
@@ -8,7 +8,7 @@ tags: [ glasskube, news, cncf ]
 
 import Install from '../../src/partials/_install.mdx';
 
-**🧊 Glasskube is the missing Package Manager for Kubernetes 📦**
+**🧊 Glasskube is the next generation Package Manager for Kubernetes 📦**
 
 Featuring a GUI and a CLI. Glasskube packages are dependency aware, GitOps ready and can get automatic updates via a central public package repository.
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -6,7 +6,7 @@ import {EnumChangefreq} from 'sitemap';
 
 const config: Config = {
   title: 'Glasskube.dev',
-  tagline: '🧊 The missing Package Manager for Kubernetes 📦',
+  tagline: '🧊 The next generation Package Manager for Kubernetes 📦',
   favicon: 'img/favicon.png',
   trailingSlash: true,
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -121,7 +121,7 @@ const config: Config = {
     announcementBar: {
       id: 'announcementBar-0', // Increment on change
       // content: '⭐️ If you like <code>glasskube</code>, give it a star on <a target="_blank" rel="noopener noreferrer" href="https://github.com/glasskube/glasskube">GitHub</a> and follow us on <a target="_blank" rel="noopener noreferrer" href="https://x.com/glasskube">X</a> ⭐️',
-      content: `🎉️ <a target="_blank" href="https://github.com/glasskube/glasskube"><code>glasskube/glasskube</code></a> is launching its technical concept on GitHub 🥳️ <a target="_blank" rel="noopener noreferrer" href="https://github.com/glasskube/glasskube">Leave a star to support us</a> ⭐️`,
+      content: `🎉️ <a target="_blank" href="https://github.com/glasskube/glasskube"><code>glasskube/glasskube</code></a> Beta is launching on <a target="_blank" rel="noopener noreferrer" href="https://www.producthunt.com/products/glasskube?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-glasskube">Producthunt</a> 🥳️`,
       isCloseable: false,
     },
     image:

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -1,8 +1,8 @@
-import { themes as prismThemes } from 'prism-react-renderer';
-import type { Config } from '@docusaurus/types';
-import type { Options as IdealImageOptions } from '@docusaurus/plugin-ideal-image';
+import {themes as prismThemes} from 'prism-react-renderer';
+import type {Config} from '@docusaurus/types';
+import type {Options as IdealImageOptions} from '@docusaurus/plugin-ideal-image';
 import type * as Preset from '@docusaurus/preset-classic';
-import { EnumChangefreq } from 'sitemap';
+import {EnumChangefreq} from 'sitemap';
 
 const config: Config = {
   title: 'Glasskube.dev',
@@ -148,17 +148,10 @@ const config: Config = {
         { to: '/blog', label: 'Blog', position: 'left' },
         { to: '/roadmap', label: 'Roadmap', position: 'left' },
         { to: '/packages', label: 'Packages', position: 'left' },
-
         {
-          href: 'https://github.com/glasskube/glasskube',
-          label: 'GitHub',
+          type: 'custom-wrapper',
           position: 'right',
-        },
-        {
-          href: 'https://x.com/glasskube',
-          label: 'Twitter / X',
-          position: 'right',
-        },
+        }
       ],
     },
     footer: {

--- a/website/src/components/CustomGitHubButton.tsx
+++ b/website/src/components/CustomGitHubButton.tsx
@@ -9,6 +9,7 @@ const CustomGitHubButton: FC<CustomGitHubButtonProps> = ({ href, ...props }) => 
   <GitHubButton
     href={href}
     data-color-scheme="no-preference: light; light: light; dark: light;"
+    data-icon="octicon-star"
     data-size="large"
     data-show-count="true"
     aria-label={`Star ${href} on GitHub`}

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -101,3 +101,7 @@
     margin: 8px 0;
   }
 }
+
+.producthunt {
+  margin-top: 20px;
+}

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -7,36 +7,17 @@ import Heading from '@theme/Heading';
 
 import styles from './index.module.css';
 import React from 'react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faStar } from '@fortawesome/free-regular-svg-icons';
-import { faXTwitter } from '@fortawesome/free-brands-svg-icons';
 import Typewriter from 'typewriter-effect';
 import BrowserOnly from '@docusaurus/BrowserOnly';
 import AsciinemaPlayer from '../components/asciinema-player';
 
 
 function HomepageHeader() {
-  const { siteConfig } = useDocusaurusContext();
+  const {siteConfig} = useDocusaurusContext();
 
   return (
     <header className={clsx('hero hero--primary', styles.heroBanner)}>
       <div className="container">
-        <div className="row">
-          <div className="col">
-            <div className={styles.socialButtons}>
-              <Link
-                className={clsx('button', 'button--secondary', styles.socialButtonsLink)}
-                to="https://github.com/glasskube/glasskube">
-                <FontAwesomeIcon icon={faStar} />&nbsp;Star
-              </Link>
-              <Link
-                className={clsx('button', 'button--secondary', styles.socialButtonsLink)}
-                to="https://x.com/intent/follow?screen_name=glasskube">
-                <FontAwesomeIcon icon={faXTwitter} />&nbsp;Follow
-              </Link>
-            </div>
-          </div>
-        </div>
         <div className="row row--no-gutters">
           <div className={clsx('col', styles.heroCol)}>
             <Heading as="h1" className="hero__title">
@@ -77,6 +58,14 @@ function HomepageHeader() {
                 Join the community
               </Link>
             </div>
+            <div className={styles.producthunt}>
+              <a
+                href="https://www.producthunt.com/posts/glasskube?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-glasskube"
+                target="_blank"><img
+                src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=452879&theme=light"
+                alt="Glasskube - &#0032;🧊&#0032;The&#0032;next&#0032;generation&#0032;Package&#0032;Manager&#0032;for&#0032;Kubernetes&#0032;📦 | Product Hunt"
+                style={{width: '250px', height: '54px'}}/></a>
+            </div>
           </div>
           <div className="col">
             <div className={styles.lottiePlayerWrapper}>
@@ -87,7 +76,7 @@ function HomepageHeader() {
                     autoplay
                     loop
                     src="/animations/home.json"
-                    style={{ height: '480px' }}
+                    style={{height: '480px'}}
                   />
                 }}
               </BrowserOnly>
@@ -101,7 +90,7 @@ function HomepageHeader() {
 }
 
 function HomepageVideo() {
-  const { siteConfig } = useDocusaurusContext();
+  const {siteConfig} = useDocusaurusContext();
 
   return (
     <div className={clsx('container-fluid', 'text--center', styles.backgroundSecondary)}>
@@ -116,7 +105,7 @@ function HomepageVideo() {
               rows='22'
               idleTimeLimit={7}
               poster='npt:0:19'
-              controls={false} />
+              controls={false}/>
           </div>
         </div>
       </div>
@@ -124,7 +113,8 @@ function HomepageVideo() {
 
   );
 }
-function loadScript () {
+
+function loadScript() {
   if (typeof window === "undefined") {
     return null;
   }
@@ -140,7 +130,7 @@ function loadScript () {
 }
 
 function HomepageNewsletter() {
-  const { siteConfig } = useDocusaurusContext();
+  const {siteConfig} = useDocusaurusContext();
 
   return (
     <div className="container text--center">
@@ -151,7 +141,7 @@ function HomepageNewsletter() {
               Glasskube Newsletter
             </Heading>
             <p>Sign-Up to get the latest product updates and release notes!</p>
-            <NewsletterForm />
+            <NewsletterForm/>
           </div>
         </div>
       </div>
@@ -163,7 +153,7 @@ function HomepageNewsletter() {
 class NewsletterForm extends React.Component<any, { value: string }> {
   constructor(props) {
     super(props);
-    this.state = { value: '' };
+    this.state = {value: ''};
 
     this.handleSubmit = this.handleSubmit.bind(this);
     this.handleChange = this.handleChange.bind(this);
@@ -173,7 +163,7 @@ class NewsletterForm extends React.Component<any, { value: string }> {
     if (!this.state.value) {
       loadScript();
     }
-    this.setState({ value: event.target.value });
+    this.setState({value: event.target.value});
   }
 
   async handleSubmit(event) {
@@ -204,9 +194,9 @@ class NewsletterForm extends React.Component<any, { value: string }> {
     return (
       <form onSubmit={this.handleSubmit} className={styles.newsletterForm}>
         <input type="email" id="email" name="email" required
-          placeholder="your-email@corp.com"
-          value={this.state.value} onChange={this.handleChange}
-          className={styles.emailInput} />
+               placeholder="your-email@corp.com"
+               value={this.state.value} onChange={this.handleChange}
+               className={styles.emailInput}/>
         <button
           className="button button--secondary button--lg"
           type="submit">
@@ -218,16 +208,16 @@ class NewsletterForm extends React.Component<any, { value: string }> {
 }
 
 export default function Home(): JSX.Element {
-  const { siteConfig } = useDocusaurusContext();
+  const {siteConfig} = useDocusaurusContext();
   return (
     <Layout
       title={siteConfig.tagline}
       description='Featuring a GUI and a CLI. Glasskube packages are dependency aware, GitOps ready and get automatic updates via a central public package repository.'>
-      <HomepageHeader />
+      <HomepageHeader/>
       <main>
-        <HomepageFeatures />
-        <HomepageVideo />
-        <HomepageNewsletter />
+        <HomepageFeatures/>
+        <HomepageVideo/>
+        <HomepageNewsletter/>
       </main>
     </Layout>
   );

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -59,12 +59,11 @@ function HomepageHeader() {
               </Link>
             </div>
             <div className={styles.producthunt}>
-              <a
-                href="https://www.producthunt.com/posts/glasskube?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-glasskube"
-                target="_blank"><img
-                src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=452879&theme=light"
-                alt="Glasskube - &#0032;🧊&#0032;The&#0032;next&#0032;generation&#0032;Package&#0032;Manager&#0032;for&#0032;Kubernetes&#0032;📦 | Product Hunt"
-                style={{width: '250px', height: '54px'}}/></a>
+              <a href="https://www.producthunt.com/products/glasskube?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-glasskube" target="_blank">
+                <img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=452879&theme=light"
+                  alt="Glasskube - &#0032;🧊&#0032;The&#0032;next&#0032;generation&#0032;Package&#0032;Manager&#0032;for&#0032;Kubernetes&#0032;📦 | Product Hunt"
+                  style={{width: '250px', height: '54px'}}/>
+              </a>
             </div>
           </div>
           <div className="col">

--- a/website/src/theme/NavbarItem/ComponentTypes.ts
+++ b/website/src/theme/NavbarItem/ComponentTypes.ts
@@ -1,0 +1,7 @@
+import ComponentTypes from '@theme-original/NavbarItem/ComponentTypes';
+import NavbarWrapper from '@site/src/theme/NavbarItem/NavbarWrapper';
+
+export default {
+  ...ComponentTypes,
+  'custom-wrapper': NavbarWrapper,
+};

--- a/website/src/theme/NavbarItem/NavbarWrapper/index.tsx
+++ b/website/src/theme/NavbarItem/NavbarWrapper/index.tsx
@@ -1,0 +1,16 @@
+import styles from './styles.module.css';
+import CustomGitHubButton from '@site/src/components/CustomGitHubButton';
+
+
+function Index() {
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.center}>
+        <CustomGitHubButton href='https://github.com/glasskube/glasskube'/>
+      </div>
+
+    </div>
+  );
+}
+
+export default Index;

--- a/website/src/theme/NavbarItem/NavbarWrapper/styles.module.css
+++ b/website/src/theme/NavbarItem/NavbarWrapper/styles.module.css
@@ -1,0 +1,19 @@
+.wrapper {
+  text-align: center;
+  width: 160px;
+  height: 28px;
+  margin: 0 auto;
+}
+
+@media (max-width: 576px) {
+  .wrapper {
+    margin-right: 36px;
+  }
+}
+
+@media (min-width: 577px) and (max-width: 996px) {
+  .wrapper {
+    margin-right: 140px;
+  }
+}
+


### PR DESCRIPTION
Closes #459

## 📑 Description
- Adding the GitHub star button (also on mobile)
- Adding the Producthunt Button on the website and README.md
- Adding an announcement bar

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
![image](https://github.com/glasskube/glasskube/assets/3041752/dca33651-1dd9-4c54-abe8-2414b814b3b8)