### PR TITLE
glasskube version show an error when not bootstrapped

### DIFF
--- a/cmd/glasskube/cmd/version.go
+++ b/cmd/glasskube/cmd/version.go
@@ -21,7 +21,8 @@ var versioncmd = &cobra.Command{
 		fmt.Fprintf(os.Stderr, "glasskube: v%s\n", glasskubeVersion)
 		operatorVersion, err := clientutils.GetPackageOperatorVersion(cmd.Context())
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "✗ no deployments found in the glasskube-system namespace\n")
+			fmt.Fprintf(os.Stderr, "package-operator: not installed\n")
+			fmt.Fprintf(os.Stderr, "Glasskube is not yet bootstrapped. Use 'glasskube bootstrap' to get started.\n")
 			cliutils.ExitWithError()
 		} else {
 			fmt.Fprintf(os.Stderr, "package-operator: %s\n", operatorVersion)


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes https://github.com/glasskube/glasskube/issues/529

## 📑 Description
<!-- Add a brief description of the pr -->
Changed the error message to show that the glasskube is not bootstrapped yet do it using glasskube bootstrap command.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->