### PR TITLE
feat(cli, ui): add markdown support in long description

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,9 @@ require (
 	github.com/posthog/posthog-go v0.0.0-20240327112532-87b23fe11103
 	github.com/schollz/progressbar/v3 v3.14.2
 	github.com/spf13/cobra v1.8.0
+	github.com/yuin/goldmark v1.7.1
 	go.uber.org/multierr v1.11.0
+	golang.org/x/term v0.18.0
 	k8s.io/api v0.29.4
 	k8s.io/apiextensions-apiserver v0.29.4
 	k8s.io/apimachinery v0.29.4
@@ -82,7 +84,6 @@ require (
 	golang.org/x/net v0.23.0 // indirect
 	golang.org/x/oauth2 v0.16.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect
-	golang.org/x/term v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	golang.org/x/tools v0.17.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -156,6 +156,8 @@ github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+x
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/goldmark v1.7.1 h1:3bajkSilaCbjdKVsKdZjZCLBNPL9pYzrCakKaf4U49U=
+github.com/yuin/goldmark v1.7.1/go.mod h1:uzxRWxtg69N339t3louHJ7+O03ezfj6PlliRlaOzY1E=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/internal/cliutils/markdown.go
+++ b/internal/cliutils/markdown.go
@@ -1,0 +1,257 @@
+package cliutils
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/util"
+	"golang.org/x/term"
+)
+
+var (
+	bold      = color.New(color.Bold)
+	italic    = color.New(color.Italic)
+	underline = color.New(color.Underline)
+	magenta   = color.New(color.FgMagenta)
+)
+
+type listContext struct {
+	ordered bool
+	index   int
+}
+
+type markdownRenderer struct {
+	listContext *listContext
+}
+
+func MarkdownRenderer() renderer.NodeRenderer {
+	return &markdownRenderer{}
+}
+
+// RegisterFuncs implements renderer.NodeRenderer.
+func (r *markdownRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
+	// blocks
+	reg.Register(ast.KindDocument, r.renderDocument)
+	reg.Register(ast.KindHeading, r.renderHeading)
+	reg.Register(ast.KindBlockquote, r.renderBlockquote)
+	reg.Register(ast.KindCodeBlock, r.renderCodeBlock)
+	reg.Register(ast.KindFencedCodeBlock, r.renderFencedCodeBlock)
+	reg.Register(ast.KindHTMLBlock, r.renderHTMLBlock)
+	reg.Register(ast.KindList, r.renderList)
+	reg.Register(ast.KindListItem, r.renderListItem)
+	reg.Register(ast.KindParagraph, r.renderParagraph)
+	reg.Register(ast.KindTextBlock, r.renderTextBlock)
+	reg.Register(ast.KindThematicBreak, r.renderThematicBreak)
+
+	// inlines
+	reg.Register(ast.KindAutoLink, r.renderAutoLink)
+	reg.Register(ast.KindCodeSpan, r.renderCodeSpan)
+	reg.Register(ast.KindEmphasis, r.renderEmphasis)
+	reg.Register(ast.KindImage, r.renderImage)
+	reg.Register(ast.KindLink, r.renderLink)
+	reg.Register(ast.KindRawHTML, r.renderRawHTML)
+	reg.Register(ast.KindText, r.renderText)
+	reg.Register(ast.KindString, r.renderString)
+}
+
+func (*markdownRenderer) renderDocument(
+	writer util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
+	return ast.WalkContinue, nil
+}
+
+func (*markdownRenderer) renderHeading(
+	writer util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
+	if entering {
+		bold.SetWriter(writer)
+	} else {
+		bold.UnsetWriter(writer)
+		fmt.Fprintln(writer)
+	}
+	return ast.WalkContinue, nil
+}
+
+func (*markdownRenderer) renderBlockquote(
+	writer util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
+	if entering {
+		italic.SetWriter(writer)
+	} else {
+		italic.UnsetWriter(writer)
+	}
+	return ast.WalkContinue, nil
+}
+
+func (r *markdownRenderer) renderCodeBlock(
+	writer util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
+	if entering {
+		r.writeLines(writer, source, n)
+		fmt.Fprintln(writer)
+	}
+	return ast.WalkContinue, nil
+}
+
+func (r *markdownRenderer) renderFencedCodeBlock(
+	writer util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
+	if entering {
+		r.writeLines(writer, source, n)
+		fmt.Fprintln(writer)
+	}
+	return ast.WalkContinue, nil
+}
+
+func (*markdownRenderer) renderHTMLBlock(
+	writer util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
+	return ast.WalkContinue, nil
+}
+
+func (r *markdownRenderer) renderList(
+	writer util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
+	if entering {
+		r.listContext = &listContext{
+			ordered: n.(*ast.List).IsOrdered(),
+		}
+	} else {
+		r.listContext = nil
+		fmt.Fprintln(writer)
+	}
+	return ast.WalkContinue, nil
+}
+
+func (r *markdownRenderer) renderListItem(
+	writer util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
+	n.Parent().(*ast.List).IsOrdered()
+	if entering {
+		if r.listContext.ordered {
+			fmt.Fprintf(writer, " %v) ", r.listContext.index+1)
+		} else {
+			fmt.Fprint(writer, " * ")
+		}
+		r.listContext.index++
+	} else {
+		fmt.Fprintln(writer)
+	}
+	return ast.WalkContinue, nil
+}
+
+func (*markdownRenderer) renderParagraph(
+	writer util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
+	if !entering {
+		fmt.Fprint(writer, "\n\n")
+	}
+	return ast.WalkContinue, nil
+}
+
+func (*markdownRenderer) renderTextBlock(
+	writer util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
+	if !entering {
+		if n.NextSibling() != nil && n.FirstChild() != nil {
+			fmt.Fprintln(writer)
+		}
+	}
+	return ast.WalkContinue, nil
+}
+
+func (*markdownRenderer) renderThematicBreak(
+	writer util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
+	if entering {
+		w, _, _ := term.GetSize(int(os.Stdout.Fd()))
+		if w <= 0 {
+			w = 40
+		}
+		_, _ = writer.WriteString(strings.Repeat("─", max(w, 40)) + "\n\n")
+	}
+	return ast.WalkContinue, nil
+}
+
+func (*markdownRenderer) renderAutoLink(
+	writer util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
+	fmt.Fprint(writer, n.Text(source))
+	if entering {
+		underline.SetWriter(writer)
+	} else {
+		underline.UnsetWriter(writer)
+	}
+	return ast.WalkContinue, nil
+}
+
+func (*markdownRenderer) renderCodeSpan(
+	writer util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
+	if entering {
+		magenta.SetWriter(writer)
+	} else {
+		magenta.UnsetWriter(writer)
+	}
+	return ast.WalkContinue, nil
+}
+
+func (*markdownRenderer) renderEmphasis(
+	writer util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
+	em := n.(*ast.Emphasis)
+	style := italic
+	if em.Level >= 2 {
+		style = bold
+	}
+	if entering {
+		style.SetWriter(writer)
+	} else {
+		style.UnsetWriter(writer)
+	}
+	return ast.WalkContinue, nil
+}
+
+func (*markdownRenderer) renderImage(
+	writer util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
+	return ast.WalkContinue, nil
+}
+
+func (*markdownRenderer) renderLink(
+	writer util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
+	l := n.(*ast.Link)
+	if !entering {
+		url := string(l.Destination)
+		if !strings.Contains(url, "://") {
+			url = "https://" + url
+		}
+		fmt.Fprintf(writer, " (%v)", underline.Sprint(url))
+	}
+	return ast.WalkContinue, nil
+}
+
+func (*markdownRenderer) renderRawHTML(
+	writer util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
+	return ast.WalkContinue, nil
+}
+
+func (*markdownRenderer) renderText(
+	writer util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
+	if entering {
+		t := n.(*ast.Text)
+		_, _ = writer.Write(t.Segment.Value(source))
+		if t.HardLineBreak() {
+			fmt.Fprintln(writer)
+		}
+		if t.SoftLineBreak() {
+			_, _ = writer.WriteRune(' ')
+		}
+	}
+	return ast.WalkContinue, nil
+}
+
+func (*markdownRenderer) renderString(
+	writer util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if entering {
+		_, _ = writer.Write(node.(*ast.String).Value)
+	}
+	return ast.WalkContinue, nil
+}
+
+func (r *markdownRenderer) writeLines(w util.BufWriter, source []byte, n ast.Node) {
+	l := n.Lines().Len()
+	for i := 0; i < l; i++ {
+		line := n.Lines().At(i)
+		_, _ = w.Write(line.Value(source))
+	}
+}

--- a/internal/web/templates.go
+++ b/internal/web/templates.go
@@ -1,12 +1,14 @@
 package web
 
 import (
+	"bytes"
 	"fmt"
 	"html/template"
 	"os"
 	"path"
 
 	"github.com/glasskube/glasskube/internal/web/components/pkg_config_input"
+	"github.com/yuin/goldmark"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/glasskube/glasskube/api/v1alpha1"
@@ -79,6 +81,13 @@ func parseTemplates() {
 		"ForAlert":          alert.ForAlert,
 		"ForPkgConfigInput": pkg_config_input.ForPkgConfigInput,
 		"IsUpgradable":      semver.IsUpgradable,
+		"Markdown": func(source string) template.HTML {
+			var buf bytes.Buffer
+			if err := goldmark.Convert([]byte(source), &buf); err != nil {
+				return template.HTML("<p>" + source + "</p>")
+			}
+			return template.HTML(buf.String())
+		},
 	}
 
 	baseTemplate = template.Must(template.New("base.html").

--- a/internal/web/templates/pages/package.html
+++ b/internal/web/templates/pages/package.html
@@ -57,22 +57,21 @@
         <div class="mt-3">
           <h2 class="text-reset">Package Details</h2>
 
-          <span>
-            {{ if eq .Manifest.LongDescription "" }}
-              <i
-                >This package has no detailed description yet. You can request to change this here:
-                <a
-                  class="icon-link text-reset me-2"
-                  href="{{ PackageManifestUrl .Manifest.Name .Package .LatestVersion }}"
-                  target="_blank">
-                  <span class="bi bi-box-arrow-up-right"></span>
-                  Glasskube Package Manifest
-                </a>
-              </i>
-            {{ else }}
-              {{ .Manifest.LongDescription }}
-            {{ end }}
-          </span>
+          {{ if eq .Manifest.LongDescription "" }}
+            <i>
+              This package has no detailed description yet. You can request to change this here:
+              <a
+                class="icon-link text-reset me-2"
+                href="{{ PackageManifestUrl .Manifest.Name .Package .LatestVersion }}"
+                target="_blank">
+                <span class="bi bi-box-arrow-up-right"></span>
+                Glasskube Package Manifest
+              </a>
+            </i>
+          {{ else }}
+            {{ .Manifest.LongDescription | Markdown }}
+          {{ end }}
+
           {{ if or (eq .Package nil) (IsUpgradable .Package.Spec.PackageInfo.Version .LatestVersion) }}
             <div class="my-1">
               <i>Latest version: {{ .LatestVersion }}</i>


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #253  <!-- Issue # here -->

## 📑 Description
This PR adds support for rendering the package LongDescription as markdown in the CLI (describe command) and UI (details page).

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
Markdown parsing is achieved using https://github.com/yuin/goldmark. For the CLI we use a custom renderer.