### PR TITLE
fix: add validating existing install before bootstrap

### DIFF
--- a/cmd/glasskube/cmd/bootstrap.go
+++ b/cmd/glasskube/cmd/bootstrap.go
@@ -15,6 +15,7 @@ type bootstrapOptions struct {
 	bootstrapType    bootstrap.BootstrapType
 	latest           bool
 	disableTelemetry bool
+	force            bool
 }
 
 var bootstrapCmdOptions = bootstrapOptions{
@@ -44,6 +45,7 @@ func (o bootstrapOptions) asBootstrapOptions() bootstrap.BootstrapOptions {
 		Url:              o.url,
 		Latest:           o.latest,
 		DisableTelemetry: o.disableTelemetry,
+		Force:            o.force,
 	}
 }
 
@@ -53,6 +55,8 @@ func init() {
 	bootstrapCmd.Flags().VarP(&bootstrapCmdOptions.bootstrapType, "type", "t", `Type of manifest to use for bootstrapping`)
 	bootstrapCmd.Flags().BoolVar(&bootstrapCmdOptions.latest, "latest", config.IsDevBuild(),
 		"Fetch and bootstrap the latest version")
+	bootstrapCmd.Flags().BoolVarP(&bootstrapCmdOptions.force, "force", "f", bootstrapCmdOptions.force,
+		"Do not bail out if pre-checks fail")
 	bootstrapCmd.Flags().BoolVar(&bootstrapCmdOptions.disableTelemetry, "disable-telemetry", false, "Disable telemetry")
 	bootstrapCmd.MarkFlagsMutuallyExclusive("url", "type")
 	bootstrapCmd.MarkFlagsMutuallyExclusive("url", "latest")


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #454 <!-- Issue # here -->

## 📑 Description
This PR adds a validation step to the bootstrap command: If any resource has the "kubectl last applied configuration" annotation, the operation is cancelled and no changes are made. This can be overridden using the new `--force` flag.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->