### PR TITLE
fix(cli): skip version check for `bootstrap`

### DIFF
--- a/cmd/glasskube/cmd/bootstrap.go
+++ b/cmd/glasskube/cmd/bootstrap.go
@@ -8,6 +8,7 @@ import (
 	"github.com/glasskube/glasskube/internal/cliutils"
 	"github.com/glasskube/glasskube/internal/config"
 	"github.com/glasskube/glasskube/internal/semver"
+	"github.com/glasskube/glasskube/internal/util"
 	"github.com/glasskube/glasskube/pkg/bootstrap"
 	"github.com/spf13/cobra"
 )
@@ -29,7 +30,7 @@ var bootstrapCmd = &cobra.Command{
 	Long: "Bootstraps Glasskube in a Kubernetes cluster, " +
 		"thereby installing the Glasskube operator and checking if the installation was successful.",
 	Args:   cobra.NoArgs,
-	PreRun: cliutils.SetupClientContext(false, &rootCmdOptions.SkipUpdateCheck),
+	PreRun: cliutils.SetupClientContext(false, util.Pointer(true)),
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg, _ := cliutils.RequireConfig(config.Kubeconfig)
 		client := bootstrap.NewBootstrapClient(cfg)

--- a/internal/util/pointer.go
+++ b/internal/util/pointer.go
@@ -1,0 +1,5 @@
+package util
+
+func Pointer[T any](obj T) *T {
+	return &obj
+}


### PR DESCRIPTION
## 📑 Description
Checking the operator version does not make sense for the `bootstrap` command, because the version is about to be upgraded anyways. This PR removes this check for the `bootstrap` command.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information

