### PR TITLE
fix(cli): version prefix v now is now optional

### DIFF
--- a/cmd/glasskube/cmd/install.go
+++ b/cmd/glasskube/cmd/install.go
@@ -64,7 +64,7 @@ var installCmd = &cobra.Command{
 			installCmdOptions.Version = packageIndex.LatestVersion
 			fmt.Fprintf(os.Stderr, "Version not specified. The latest version %v of %v will be installed.\n",
 				installCmdOptions.Version, packageName)
-		} else if installCmdOptions.Version[:1] != "v" { // the slice notation is used to get a string instead of byte
+		} else if !strings.HasPrefix(updateCmdOptions.Version, "v") {
 			installCmdOptions.Version = "v" + installCmdOptions.Version
 		}
 

--- a/cmd/glasskube/cmd/install.go
+++ b/cmd/glasskube/cmd/install.go
@@ -64,6 +64,8 @@ var installCmd = &cobra.Command{
 			installCmdOptions.Version = packageIndex.LatestVersion
 			fmt.Fprintf(os.Stderr, "Version not specified. The latest version %v of %v will be installed.\n",
 				installCmdOptions.Version, packageName)
+		} else if installCmdOptions.Version[:1] != "v" { // the slice notation is used to get a string instead of byte
+			installCmdOptions.Version = "v" + installCmdOptions.Version
 		}
 
 		pkgBuilder.WithVersion(installCmdOptions.Version)

--- a/cmd/glasskube/cmd/install.go
+++ b/cmd/glasskube/cmd/install.go
@@ -64,7 +64,7 @@ var installCmd = &cobra.Command{
 			installCmdOptions.Version = packageIndex.LatestVersion
 			fmt.Fprintf(os.Stderr, "Version not specified. The latest version %v of %v will be installed.\n",
 				installCmdOptions.Version, packageName)
-		} else if !strings.HasPrefix(updateCmdOptions.Version, "v") {
+		} else if !strings.HasPrefix(installCmdOptions.Version, "v") {
 			installCmdOptions.Version = "v" + installCmdOptions.Version
 		}
 

--- a/cmd/glasskube/cmd/update.go
+++ b/cmd/glasskube/cmd/update.go
@@ -44,6 +44,9 @@ var updateCmd = &cobra.Command{
 			cliutils.ExitWithError()
 		}
 		if len(args) == 1 && updateCmdOptions.Version != "" {
+			if updateCmdOptions.Version[:1] != "v" { // the slice notation is used to get a string instead of byte
+				updateCmdOptions.Version = "v" + updateCmdOptions.Version
+			}
 			tx, err = updater.PrepareForVersion(ctx, args[0], updateCmdOptions.Version)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "error in updating the package version : %v\n", err)

--- a/cmd/glasskube/cmd/update.go
+++ b/cmd/glasskube/cmd/update.go
@@ -44,7 +44,7 @@ var updateCmd = &cobra.Command{
 			cliutils.ExitWithError()
 		}
 		if len(args) == 1 && updateCmdOptions.Version != "" {
-			if updateCmdOptions.Version[:1] != "v" { // the slice notation is used to get a string instead of byte
+			if !strings.HasPrefix(updateCmdOptions.Version, "v") {
 				updateCmdOptions.Version = "v" + updateCmdOptions.Version
 			}
 			tx, err = updater.PrepareForVersion(ctx, args[0], updateCmdOptions.Version)


### PR DESCRIPTION

<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #463

## 📑 Description
The PR make changes to `-v/--version` in the glasskube cli. Previously it requires the user to add "v" prefix to the version. With the PR the user will be able to pass exact version and the code internally adds a "v" prefix. 

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information