### PR TITLE
chore(main): add stale issue/pr removal automation

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,24 @@
+name: "Close stale issues and PRs"
+on:
+  schedule:
+    - cron: "30 1 * * *" # Every day at 1:30 UTC
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: "This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 14 days. If a Glasskube team member has requested log or more information, please provide the output of the shared commands."
+          close-issue-message: "This issue was closed because it has been stalled for 14 days with no activity."
+          days-before-issue-stale: 60
+          days-before-issue-close: 14
+          stale-issue-label: staled
+          include-only-assigned: true
+          # Disable stale PRs for now; they can remain open.
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          # Only issues made after Feb 09 2021.
+          start-date: "2021-09-02T00:00:00"
+          exempt-issue-labels: "autorelease: pending,critical,needs-triage,epic,autorelease: tagged"


### PR DESCRIPTION
## 📑 Description
Added a GitHub actions automation to remove stale PRs and Issue after 60 days, while first issuing a warning.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->