### PR TITLE
feat(cli): add json and yaml format in the list sub-command

### DIFF
--- a/cmd/glasskube/cmd/list.go
+++ b/cmd/glasskube/cmd/list.go
@@ -157,18 +157,15 @@ func printPackageJSON(packages []*list.PackageWithStatus) {
 }
 
 func printPackageYAML(packages []*list.PackageWithStatus) {
-	var isFirstPackage = true
 
-	for _, pkg := range packages {
+	for i, pkg := range packages {
 		yamlData, err := yaml.Marshal(pkg)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error marshaling data to YAML: %v\n", err)
 			cliutils.ExitWithError()
 		}
 
-		if isFirstPackage {
-			isFirstPackage = false
-		} else {
+		if i > 0 {
 			fmt.Println("---")
 		}
 

--- a/cmd/glasskube/cmd/list.go
+++ b/cmd/glasskube/cmd/list.go
@@ -157,14 +157,22 @@ func printPackageJSON(packages []*list.PackageWithStatus) {
 }
 
 func printPackageYAML(packages []*list.PackageWithStatus) {
+	var isFirstPackage = true
+
 	for _, pkg := range packages {
 		yamlData, err := yaml.Marshal(pkg)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error marshaling data to YAML: %v\n", err)
 			cliutils.ExitWithError()
 		}
+
+		if isFirstPackage {
+			isFirstPackage = false
+		} else {
+			fmt.Println("---")
+		}
+
 		fmt.Println(string(yamlData))
-		fmt.Println("---")
 	}
 }
 

--- a/cmd/glasskube/cmd/list.go
+++ b/cmd/glasskube/cmd/list.go
@@ -12,6 +12,7 @@ import (
 	"github.com/glasskube/glasskube/pkg/client"
 	"github.com/glasskube/glasskube/pkg/list"
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
 )
 
 type ListCmdOptions struct {
@@ -63,6 +64,8 @@ var listCmd = &cobra.Command{
 		} else {
 			if listCmdOptions.ListFormat == "json" {
 				printPackageJSON(pkgs)
+			} else if listCmdOptions.ListFormat == "yaml" {
+				printPackageYAML(pkgs)
 			} else {
 				printPackageTable(pkgs)
 			}
@@ -124,6 +127,18 @@ func printPackageJSON(packages []*list.PackageWithStatus) {
 		cliutils.ExitWithError()
 	}
 	fmt.Println(string(jsonData))
+}
+
+func printPackageYAML(packages []*list.PackageWithStatus) {
+	for _, pkg := range packages {
+		yamlData, err := yaml.Marshal(pkg)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error marshaling data to YAML: %v\n", err)
+			cliutils.ExitWithError()
+		}
+		fmt.Println(string(yamlData))
+		fmt.Println("---")
+	}
 }
 
 func statusString(pkg list.PackageWithStatus) string {

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	k8s.io/apimachinery v0.30.1
 	k8s.io/client-go v0.30.1
 	sigs.k8s.io/controller-runtime v0.18.2
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -98,5 +99,4 @@ require (
 	k8s.io/utils v0.0.0-20240102154912-e7106e64919e // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/pkg/list/list.go
+++ b/pkg/list/list.go
@@ -14,7 +14,7 @@ import (
 
 type PackageWithStatus struct {
 	repo.PackageRepoIndexItem
-	Status            *client.PackageStatus
+	Status            *client.PackageStatus `json:"status,omitempty"`
 	Package           *v1alpha1.Package
 	InstalledManifest *v1alpha1.PackageManifest
 }

--- a/pkg/list/list.go
+++ b/pkg/list/list.go
@@ -14,9 +14,9 @@ import (
 
 type PackageWithStatus struct {
 	repo.PackageRepoIndexItem
-	Status            *client.PackageStatus `json:"status,omitempty"`
-	Package           *v1alpha1.Package
-	InstalledManifest *v1alpha1.PackageManifest
+	Status            *client.PackageStatus     `json:"status,omitempty"`
+	Package           *v1alpha1.Package         `json:"package,omitempty"`
+	InstalledManifest *v1alpha1.PackageManifest `json:"installedmanifest,omitempty"`
 }
 
 type ListOptions struct {


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #465 
Fixes #465

## 📑 Description
<!-- Add a brief description of the pr -->
This PR adds the feature of printing the list subcommand in the `json` format.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
In this code I tried the `JSON.Marshal()` function but the output was not quite readable, hence went with the approach of 
`JSON.MarshalIndent()`.