### PR TITLE
feat(ui): show uninstalling button if a package is currently being uninstalled (#456)

### DIFF
--- a/internal/web/components/pkg_detail_btns/controller.go
+++ b/internal/web/components/pkg_detail_btns/controller.go
@@ -15,6 +15,7 @@ type pkgDetailBtnsInput struct {
 	Status          *client.PackageStatus
 	Manifest        *v1alpha1.PackageManifest
 	UpdateAvailable bool
+	Pkg             *v1alpha1.Package
 }
 
 func getId(pkgName string) string {
@@ -35,5 +36,6 @@ func ForPkgDetailBtns(
 		Status:          status,
 		Manifest:        manifest,
 		UpdateAvailable: updateAvailable,
+		Pkg:             pkg,
 	}
 }

--- a/internal/web/components/pkg_overview_btn/controller.go
+++ b/internal/web/components/pkg_overview_btn/controller.go
@@ -16,6 +16,7 @@ type pkgOverviewBtnInput struct {
 	Status          *client.PackageStatus
 	Manifest        *v1alpha1.PackageManifest
 	UpdateAvailable bool
+	Pkg             *v1alpha1.Package
 }
 
 func getButtonId(pkgName string) string {
@@ -30,5 +31,6 @@ func ForPkgOverviewBtn(packageWithStatus *list.PackageWithStatus, updateAvailabl
 		Status:          packageWithStatus.Status,
 		Manifest:        packageWithStatus.InstalledManifest,
 		UpdateAvailable: updateAvailable,
+		Pkg:             packageWithStatus.Package,
 	}
 }

--- a/internal/web/templates/components/pkg-detail-btns.html
+++ b/internal/web/templates/components/pkg-detail-btns.html
@@ -33,7 +33,9 @@
 {{ define "pkg-detail-btns" }}
   <span id="{{ .ContainerId }}" hx-swap="none">
     {{ if ne .Status nil }}
-      {{ if eq .Status.Status "Pending" }}
+      {{ if not .Pkg.DeletionTimestamp.IsZero }}
+        <button type="button" class="btn btn-primary btn-sm fw-medium" disabled>Uninstalling</button>
+      {{ else if eq .Status.Status "Pending" }}
         <button type="button" class="btn btn-primary btn-sm fw-medium" disabled>Pending</button>
       {{ else if eq .Status.Status "Failed" }}
         <a class="btn btn-danger btn-sm pe-none">

--- a/internal/web/templates/components/pkg-overview-btn.html
+++ b/internal/web/templates/components/pkg-overview-btn.html
@@ -10,6 +10,10 @@
         class="btn btn-primary btn-sm w-100"
         >Install</a
       >
+    {{ else if not .Pkg.DeletionTimestamp.IsZero }}
+      <div>
+        <button type="button" class="btn btn-primary btn-sm fw-medium w-100" disabled>Uninstalling</button>
+      </div>
     {{ else if eq .Status.Status "Pending" }}
       <button type="button" class="btn btn-primary btn-sm fw-medium w-100" disabled>Pending</button>
     {{ else if eq .Status.Status "Failed" }}


### PR DESCRIPTION
…installed (#456)

<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #456 

## 📑 Description
<!-- Add a brief description of the pr -->
Shows Uninstalling package button when the package is being uninstalled

On package overview page
![image](https://github.com/glasskube/glasskube/assets/69910615/d2cabce1-744a-45c7-b200-bcc16fa883e0)

On package details page
![image](https://github.com/glasskube/glasskube/assets/69910615/6fa91980-7918-4f25-9fc0-1d45353fa7d2)


## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->