### PR TITLE
feat(cli): add json and yaml output to the describe command

### DIFF
--- a/cmd/glasskube/cmd/describe.go
+++ b/cmd/glasskube/cmd/describe.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -15,6 +17,7 @@ import (
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/renderer"
 	"github.com/yuin/goldmark/util"
+	"sigs.k8s.io/yaml"
 
 	"github.com/glasskube/glasskube/internal/cliutils"
 	"github.com/glasskube/glasskube/pkg/client"
@@ -22,6 +25,44 @@ import (
 	"github.com/glasskube/glasskube/pkg/describe"
 	"github.com/spf13/cobra"
 )
+
+type DescribeOutput struct {
+	Package         string              `json:"package"`
+	Version         string              `json:"version"`
+	Status          string              `json:"status"`
+	AutoUpdate      string              `json:"autoUpdate,omitempty"`
+	Entrypoints     []map[string]string `json:"entrypoints,omitempty"`
+	Dependencies    []map[string]string `json:"dependencies,omitempty"`
+	References      []map[string]string `json:"references,omitempty"`
+	LongDescription string              `json:"longDescription,omitempty"`
+	Configuration   map[string]string   `json:"configuration,omitempty"`
+}
+
+type DescribeFormat string
+
+func (o *DescribeFormat) String() string {
+	return string(*o)
+}
+
+func (o *DescribeFormat) Set(value string) error {
+	switch value {
+	case string(JSON), string(YAML):
+		*o = DescribeFormat(value)
+		return nil
+	default:
+		return errors.New(`invalid output format, must be "json" or "yaml"`)
+	}
+}
+
+func (o *DescribeFormat) Type() string {
+	return "string"
+}
+
+type DescribeOpt struct {
+	DescribeFormat DescribeFormat
+}
+
+var describeCmdOpt = DescribeOpt{}
 
 var describeCmd = &cobra.Command{
 	Use:               "describe [package-name]",
@@ -37,42 +78,50 @@ var describeCmd = &cobra.Command{
 			fmt.Fprintf(os.Stderr, "❌ Could not describe package %v: %v\n", pkgName, err)
 			cliutils.ExitWithError()
 		}
-		bold := color.New(color.Bold).SprintFunc()
 
-		fmt.Println(bold("Package:"), nameAndDescription(manifest))
-		fmt.Println(bold("Version:"), version(pkg, latestVersion))
-		fmt.Println(bold("Status: "), status(pkgStatus))
-		if pkg != nil {
-			fmt.Println(bold("Auto-Update:"), clientutils.AutoUpdateString(pkg, "Disabled"))
-		}
+		if describeCmdOpt.DescribeFormat == DescribeFormat(JSON) {
+			printJson(pkg, pkgStatus, manifest, latestVersion)
+		} else if describeCmdOpt.DescribeFormat == DescribeFormat(YAML) {
+			printYaml(pkg, pkgStatus, manifest, latestVersion)
+		} else {
 
-		if len(manifest.Entrypoints) > 0 {
+			bold := color.New(color.Bold).SprintFunc()
+
+			fmt.Println(bold("Package:"), nameAndDescription(manifest))
+			fmt.Println(bold("Version:"), version(pkg, latestVersion))
+			fmt.Println(bold("Status: "), status(pkgStatus))
+			if pkg != nil {
+				fmt.Println(bold("Auto-Update:"), clientutils.AutoUpdateString(pkg, "Disabled"))
+			}
+
+			if len(manifest.Entrypoints) > 0 {
+				fmt.Println()
+				fmt.Println(bold("Entrypoints:"))
+				printEntrypoints(manifest)
+			}
+
+			if len(manifest.Dependencies) > 0 {
+				fmt.Println()
+				fmt.Println(bold("Dependencies:"))
+				printDependencies(manifest)
+			}
+
 			fmt.Println()
-			fmt.Println(bold("Entrypoints:"))
-			printEntrypoints(manifest)
-		}
+			fmt.Printf("%v \n", bold("References:"))
+			printReferences(pkg, manifest, latestVersion)
 
-		if len(manifest.Dependencies) > 0 {
-			fmt.Println()
-			fmt.Println(bold("Dependencies:"))
-			printDependencies(manifest)
-		}
+			trimmedDescription := strings.TrimSpace(manifest.LongDescription)
+			if len(trimmedDescription) > 0 {
+				fmt.Println()
+				fmt.Println(bold("Long Description:"))
+				printMarkdown(os.Stdout, trimmedDescription)
+			}
 
-		fmt.Println()
-		fmt.Printf("%v \n", bold("References:"))
-		printReferences(pkg, manifest, latestVersion)
-
-		trimmedDescription := strings.TrimSpace(manifest.LongDescription)
-		if len(trimmedDescription) > 0 {
-			fmt.Println()
-			fmt.Println(bold("Long Description:"))
-			printMarkdown(os.Stdout, trimmedDescription)
-		}
-
-		if pkg != nil && len(pkg.Spec.Values) > 0 {
-			fmt.Println()
-			fmt.Println(bold("Configuration:"))
-			printValueConfigurations(os.Stdout, pkg.Spec.Values)
+			if pkg != nil && len(pkg.Spec.Values) > 0 {
+				fmt.Println()
+				fmt.Println(bold("Configuration:"))
+				printValueConfigurations(os.Stdout, pkg.Spec.Values)
+			}
 		}
 	},
 }
@@ -155,14 +204,14 @@ func status(pkgStatus *client.PackageStatus) string {
 	if pkgStatus != nil {
 		switch pkgStatus.Status {
 		case string(condition.Ready):
-			return color.GreenString(pkgStatus.Status)
+			return pkgStatus.Status
 		case string(condition.Failed):
-			return color.RedString(pkgStatus.Status)
+			return pkgStatus.Status
 		default:
 			return pkgStatus.Status
 		}
 	} else {
-		return color.New(color.Faint).Sprint("Not installed")
+		return "Not installed"
 	}
 }
 
@@ -189,6 +238,118 @@ func nameAndDescription(manifest *v1alpha1.PackageManifest) string {
 	return bld.String()
 }
 
+func getEntrypoints(manifest *v1alpha1.PackageManifest) []map[string]string {
+	var entrypoints []map[string]string
+	for _, i := range manifest.Entrypoints {
+		entrypoint := make(map[string]string)
+		if i.Name != "" {
+			entrypoint["name"] = i.Name
+		}
+		if i.ServiceName != "" {
+			entrypoint["remote"] = fmt.Sprintf("%s:%v", i.ServiceName, i.Port)
+		}
+		var localUrl string
+		if i.Scheme != "" {
+			localUrl += i.Scheme + "://localhost:"
+		} else {
+			localUrl += "http://localhost:"
+		}
+		if i.LocalPort != 0 {
+			localUrl += fmt.Sprint(i.LocalPort)
+		} else {
+			localUrl += fmt.Sprint(i.Port)
+		}
+		localUrl += "/"
+		entrypoint["local"] = localUrl
+		entrypoints = append(entrypoints, entrypoint)
+	}
+	return entrypoints
+}
+
+func getDependencies(manifest *v1alpha1.PackageManifest) []map[string]string {
+	var dependencies []map[string]string
+	for _, dep := range manifest.Dependencies {
+		dependency := make(map[string]string)
+		dependency["name"] = dep.Name
+		if len(dep.Version) > 0 {
+			dependency["version"] = dep.Version
+		}
+		dependencies = append(dependencies, dependency)
+	}
+	return dependencies
+}
+
+func getReferences(manifest *v1alpha1.PackageManifest, latestVersion string) []map[string]string {
+	var references []map[string]string
+	if url, err := repo.GetPackageManifestURL("", manifest.Name, latestVersion); err == nil {
+		references = append(references, map[string]string{
+			"label": "Glasskube Package Manifest",
+			"url":   url,
+		})
+	}
+	for _, ref := range manifest.References {
+		references = append(references, map[string]string{
+			"label": ref.Label,
+			"url":   ref.Url,
+		})
+	}
+	return references
+}
+
+func getConfigurations(pkg *v1alpha1.Package) map[string]string {
+	configuration := make(map[string]string)
+	if pkg != nil && len(pkg.Spec.Values) > 0 {
+		for name, value := range pkg.Spec.Values {
+			configuration[name] = manifestvalues.ValueAsString(value)
+		}
+	}
+	return configuration
+}
+
+func printJson(pkg *v1alpha1.Package, pkgStatus *client.PackageStatus, manifest *v1alpha1.PackageManifest, latestVersion string) {
+	output := DescribeOutput{
+		Package:         nameAndDescription(manifest),
+		Version:         version(pkg, latestVersion),
+		Status:          status(pkgStatus),
+		AutoUpdate:      clientutils.AutoUpdateString(pkg, "Disabled"),
+		Entrypoints:     getEntrypoints(manifest),
+		Dependencies:    getDependencies(manifest),
+		References:      getReferences(manifest, latestVersion),
+		LongDescription: manifest.LongDescription,
+		Configuration:   getConfigurations(pkg),
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "    ")
+	err := enc.Encode(output)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error marshaling data to JSON: %v\n", err)
+		cliutils.ExitWithError()
+	}
+}
+
+func printYaml(pkg *v1alpha1.Package, pkgStatus *client.PackageStatus, manifest *v1alpha1.PackageManifest, latestVersion string) {
+	output := DescribeOutput{
+		Package:         nameAndDescription(manifest),
+		Version:         version(pkg, latestVersion),
+		Status:          status(pkgStatus),
+		AutoUpdate:      clientutils.AutoUpdateString(pkg, "Disabled"),
+		Entrypoints:     getEntrypoints(manifest),
+		Dependencies:    getDependencies(manifest),
+		References:      getReferences(manifest, latestVersion),
+		LongDescription: manifest.LongDescription,
+		Configuration:   getConfigurations(pkg),
+	}
+
+	data, err := yaml.Marshal(output)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error marshaling data to YAML: %v\n", err)
+		cliutils.ExitWithError()
+	}
+	fmt.Println(string(data))
+}
+
 func init() {
 	RootCmd.AddCommand(describeCmd)
+	describeCmd.PersistentFlags().VarP((&describeCmdOpt.DescribeFormat), "output", "o", "output format (json, yaml, etc.)")
 }

--- a/cmd/glasskube/cmd/describe.go
+++ b/cmd/glasskube/cmd/describe.go
@@ -239,7 +239,7 @@ func nameAndDescription(manifest *v1alpha1.PackageManifest) string {
 }
 
 func getEntrypoints(manifest *v1alpha1.PackageManifest) []map[string]string {
-	var entrypoints []map[string]string
+	entrypoints := []map[string]string{}
 	for _, i := range manifest.Entrypoints {
 		entrypoint := make(map[string]string)
 		if i.Name != "" {
@@ -267,7 +267,7 @@ func getEntrypoints(manifest *v1alpha1.PackageManifest) []map[string]string {
 }
 
 func getDependencies(manifest *v1alpha1.PackageManifest) []map[string]string {
-	var dependencies []map[string]string
+	dependencies := []map[string]string{}
 	for _, dep := range manifest.Dependencies {
 		dependency := make(map[string]string)
 		dependency["name"] = dep.Name
@@ -280,7 +280,7 @@ func getDependencies(manifest *v1alpha1.PackageManifest) []map[string]string {
 }
 
 func getReferences(manifest *v1alpha1.PackageManifest, latestVersion string) []map[string]string {
-	var references []map[string]string
+	references := []map[string]string{}
 	if url, err := repo.GetPackageManifestURL("", manifest.Name, latestVersion); err == nil {
 		references = append(references, map[string]string{
 			"label": "Glasskube Package Manifest",

--- a/cmd/glasskube/cmd/describe.go
+++ b/cmd/glasskube/cmd/describe.go
@@ -46,7 +46,7 @@ func (o *DescribeFormat) String() string {
 
 func (o *DescribeFormat) Set(value string) error {
 	switch value {
-	case string(JSON), string(YAML):
+	case JSON, YAML:
 		*o = DescribeFormat(value)
 		return nil
 	default:

--- a/cmd/glasskube/cmd/describe.go
+++ b/cmd/glasskube/cmd/describe.go
@@ -306,7 +306,11 @@ func getConfigurations(pkg *v1alpha1.Package) map[string]string {
 	return configuration
 }
 
-func printJson(pkg *v1alpha1.Package, pkgStatus *client.PackageStatus, manifest *v1alpha1.PackageManifest, latestVersion string) {
+func printJson(
+	pkg *v1alpha1.Package,
+	pkgStatus *client.PackageStatus,
+	manifest *v1alpha1.PackageManifest,
+	latestVersion string) {
 	output := DescribeOutput{
 		Package:         nameAndDescription(manifest),
 		Version:         version(pkg, latestVersion),
@@ -328,7 +332,11 @@ func printJson(pkg *v1alpha1.Package, pkgStatus *client.PackageStatus, manifest 
 	}
 }
 
-func printYaml(pkg *v1alpha1.Package, pkgStatus *client.PackageStatus, manifest *v1alpha1.PackageManifest, latestVersion string) {
+func printYaml(
+	pkg *v1alpha1.Package,
+	pkgStatus *client.PackageStatus,
+	manifest *v1alpha1.PackageManifest,
+	latestVersion string) {
 	output := DescribeOutput{
 		Package:         nameAndDescription(manifest),
 		Version:         version(pkg, latestVersion),

--- a/cmd/glasskube/cmd/list.go
+++ b/cmd/glasskube/cmd/list.go
@@ -29,7 +29,7 @@ func (o *ListFormat) String() string {
 
 func (o *ListFormat) Set(value string) error {
 	switch value {
-	case string(JSON), string(YAML):
+	case JSON, YAML:
 		*o = ListFormat(value)
 		return nil
 	default:

--- a/cmd/glasskube/cmd/list.go
+++ b/cmd/glasskube/cmd/list.go
@@ -18,9 +18,9 @@ import (
 
 type ListFormat string
 
-const (
-	JSON ListFormat = "json"
-	YAML ListFormat = "yaml"
+var (
+	JSON string = "json"
+	YAML string = "yaml"
 )
 
 func (o *ListFormat) String() string {
@@ -88,9 +88,9 @@ var listCmd = &cobra.Command{
 				fmt.Fprintln(os.Stderr, "No packages found. This is probably a bug.")
 			}
 		} else {
-			if listCmdOptions.ListFormat == JSON {
+			if listCmdOptions.ListFormat == ListFormat(JSON) {
 				printPackageJSON(pkgs)
-			} else if listCmdOptions.ListFormat == YAML {
+			} else if listCmdOptions.ListFormat == ListFormat(YAML) {
 				printPackageYAML(pkgs)
 			} else {
 				printPackageTable(pkgs)
@@ -111,7 +111,7 @@ func init() {
 		"show the latest version of packages if available")
 	listCmd.PersistentFlags().BoolVarP(&listCmdOptions.More, "more", "m", false,
 		"show additional information about packages (like --show-description --show-latest)")
-	listCmd.PersistentFlags().VarP((&listCmdOptions.ListFormat), "output", "o", "output format (json, yaml, etc.)")
+	listCmd.PersistentFlags().VarP((&listCmdOptions.ListFormat), "output", "o", "output format (json, yaml)")
 
 	listCmd.MarkFlagsMutuallyExclusive("show-description", "more")
 	listCmd.MarkFlagsMutuallyExclusive("show-latest", "more")


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #655 
Fixes #655 

## 📑 Description
This PR adds the feature of getting the output in the `JSON` and `YAML` formats.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
I have made changes in the `list.go` to0, here the JSON and YAM was defined as `ListFormat` which will return an error if used somewhere else. Hence I declared them to string and called them as `ListFormat(JSON)`