### PR TITLE
refactor: auto-update label to annotation

### DIFF
--- a/internal/clientutils/autoupdate.go
+++ b/internal/clientutils/autoupdate.go
@@ -8,8 +8,8 @@ import (
 
 func AutoUpdateString(pkg *v1alpha1.Package, disabledStr string) string {
 	if pkg != nil {
-		if pkg.Labels != nil {
-			autoUpdateValue, ok := pkg.Labels["packages.glasskube.dev/auto-update"]
+		if pkg.Annotations != nil {
+			autoUpdateValue, ok := pkg.Annotations["packages.glasskube.dev/auto-update"]
 			autoUpdateBool, _ := strconv.ParseBool(autoUpdateValue)
 			if ok && autoUpdateBool {
 				return "Enabled"

--- a/internal/telemetry/properties/builder.go
+++ b/internal/telemetry/properties/builder.go
@@ -79,7 +79,7 @@ func FromPackage(pkg *v1alpha1.Package) PropertiesBuilderFn {
 			Set("package_version_actual", pkg.Status.Version).
 			// TODO: set_once ?
 			Set("package_creation_timestamp", pkg.CreationTimestamp).
-			Set("package_auto_update", pkg.Labels["packages.glasskube.dev/auto-update"]).
+			Set("package_auto_update", pkg.Annotations["packages.glasskube.dev/auto-update"]).
 			Set("package_repository_name", pkg.Spec.PackageInfo.RepositoryName)
 		if c := meta.FindStatusCondition(pkg.Status.Conditions, string(condition.Ready)); c != nil {
 			p.Set("package_ready_status", c.Status)

--- a/pkg/client/builder.go
+++ b/pkg/client/builder.go
@@ -55,7 +55,7 @@ func (b *packageBuilder) Build() *v1alpha1.Package {
 		},
 	}
 	if b.autoUpdate {
-		pkg.SetLabels(map[string]string{
+		pkg.SetAnnotations(map[string]string{
 			"packages.glasskube.dev/auto-update": "true",
 		})
 	}


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #634 

## 📑 Description
This pull request refactors the codebase to utilize annotations for managing package auto-update information. This aligns with recommended practices in Kubernetes, as annotations are the preferred method for storing non-identifying, descriptive information.

### Context:

Previously, the `packages.glasskube.dev/auto-update` label served the purpose of indicating whether a package should be automatically updated. However, labels are more suited for identifying resources, while annotations provide a better fit for non-critical data like auto-update settings.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
This change ensures consistency and adherence to Kubernetes best practices, without altering the intended functionality for automatic package updates.