### PR TITLE
feat(cli): add flag to trigger non-interactive mode

### DIFF
--- a/cmd/glasskube/cmd/root.go
+++ b/cmd/glasskube/cmd/root.go
@@ -50,4 +50,7 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&config.Kubeconfig, "kubeconfig", "",
 		fmt.Sprintf("path to the kubeconfig file, whose current-context will be used (defaults to %v)",
 			clientcmd.RecommendedHomeFile))
+	RootCmd.PersistentFlags().BoolVar(&config.NonInteractive, "non-interactive", config.NonInteractive,
+		"run in non-interactive mode. "+
+			"If interactivity would be required, the command will terminate with a non-zero exit code.")
 }

--- a/internal/cliutils/inputs.go
+++ b/internal/cliutils/inputs.go
@@ -6,7 +6,17 @@ import (
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/glasskube/glasskube/internal/config"
 )
+
+// InteractivityEnabledOrFail checks whether config.NonInteractive is set and immediately aborts if it is not.
+func InteractivityEnabledOrFail() {
+	if config.NonInteractive {
+		fmt.Fprintln(os.Stderr, "\n❌ Interactivity was requested in non-interactive mode")
+		ExitWithError()
+	}
+}
 
 func YesNoPrompt(label string, defaultChoice bool) bool {
 	choices := "Y/n"
@@ -18,6 +28,7 @@ func YesNoPrompt(label string, defaultChoice bool) bool {
 	var s string
 	for {
 		fmt.Fprintf(os.Stderr, "%s (%s) ", label, choices)
+		InteractivityEnabledOrFail()
 		s, _ = r.ReadString('\n')
 		s = strings.TrimSpace(s)
 		if s == "" {
@@ -35,6 +46,7 @@ func YesNoPrompt(label string, defaultChoice bool) bool {
 
 func GetInputStr(label string) (input string) {
 	fmt.Fprintf(os.Stderr, "%v> ", label)
+	InteractivityEnabledOrFail()
 	fmt.Scanln(&input)
 	return
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,10 +3,11 @@ package config
 const defaultVersion = "dev"
 
 var (
-	Kubeconfig string
-	Version    = defaultVersion
-	Commit     = "none"
-	Date       = "unknown"
+	Kubeconfig     string
+	NonInteractive bool
+	Version        = defaultVersion
+	Commit         = "none"
+	Date           = "unknown"
 )
 
 func IsDevBuild() bool {


### PR DESCRIPTION


## 📑 Description
This PR adds a new persistent flag to the root command: `--non-interactive`. If this flag is used and the application would reach a state where it would normally wait for user input, it will instead show an error message and terminate with an error code.

## ✅ Checks
- [x] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information