### PR TITLE
fix(package-operator): add missing repoclient

### DIFF
--- a/cmd/package-operator/main.go
+++ b/cmd/package-operator/main.go
@@ -113,6 +113,7 @@ func main() {
 		Scheme:            mgr.GetScheme(),
 		HelmAdapter:       flux.NewAdapter(),
 		ManifestAdapter:   plain.NewAdapter(),
+		RepoClientset:     repoClient,
 		DependencyManager: dependencyManager,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Package")


### PR DESCRIPTION
## 📑 Description
This PR fixes a but that causes the operator to crash repeatedly when trying to install a package with dependencies

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->