### PR TITLE
feat: add --no-progress cli flag (glasskube#709)

### DIFF
--- a/cmd/glasskube/cmd/install.go
+++ b/cmd/glasskube/cmd/install.go
@@ -50,7 +50,12 @@ var installCmd = &cobra.Command{
 		dm := cliutils.DependencyManager(ctx)
 		valueResolver := cliutils.ValueResolver(ctx)
 		repoClientset := cliutils.RepositoryClientset(ctx)
-		installer := install.NewInstaller(pkgClient).WithStatusWriter(statuswriter.Spinner())
+		installer := install.NewInstaller(pkgClient)
+
+		if !rootCmdOptions.NoProgress {
+			installer.WithStatusWriter(statuswriter.Spinner())
+		}
+
 		bold := color.New(color.Bold).SprintFunc()
 		packageName := args[0]
 		pkgBuilder := client.PackageBuilder(packageName)

--- a/cmd/glasskube/cmd/root.go
+++ b/cmd/glasskube/cmd/root.go
@@ -15,6 +15,7 @@ import (
 
 var rootCmdOptions struct {
 	SkipUpdateCheck bool
+	NoProgress      bool
 }
 
 var (
@@ -53,4 +54,6 @@ func init() {
 	RootCmd.PersistentFlags().BoolVar(&config.NonInteractive, "non-interactive", config.NonInteractive,
 		"run in non-interactive mode. "+
 			"If interactivity would be required, the command will terminate with a non-zero exit code.")
+	RootCmd.PersistentFlags().BoolVar(&rootCmdOptions.NoProgress, "no-progress", false,
+		"Prevent progress logging to the cli")
 }

--- a/cmd/glasskube/cmd/uninstall.go
+++ b/cmd/glasskube/cmd/uninstall.go
@@ -50,7 +50,11 @@ var uninstallCmd = &cobra.Command{
 			}
 		}
 
-		uninstaller := uninstall.NewUninstaller(client).WithStatusWriter(statuswriter.Spinner())
+		uninstaller := uninstall.NewUninstaller(client)
+		if !rootCmdOptions.NoProgress {
+			uninstaller.WithStatusWriter(statuswriter.Spinner())
+		}
+
 		pkg := pkgClient.NewPackage(pkgName, "")
 		if uninstallCmdOptions.NoWait {
 			if err := uninstaller.Uninstall(ctx, pkg); err != nil {

--- a/cmd/glasskube/cmd/update.go
+++ b/cmd/glasskube/cmd/update.go
@@ -33,8 +33,11 @@ var updateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
 		packageNames := args
-		updater := update.NewUpdater(ctx).
-			WithStatusWriter(statuswriter.Spinner())
+
+		updater := update.NewUpdater(ctx)
+		if !rootCmdOptions.NoProgress {
+			updater.WithStatusWriter(statuswriter.Spinner())
+		}
 
 		var tx *update.UpdateTransaction
 		var err error


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #709 

## 📑 Description
This PR adds support for `--no-progress` flag applicable globally to glasskube cli for the prevention of status/progress logging during the execution of a command. Currently affected commands are:
1. `install`
2. `uninstall`
3. `update`

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->