### PR TITLE
fix: remove optimistic cache check to prevent data race

### DIFF
--- a/internal/repo/client/defaultclient.go
+++ b/internal/repo/client/defaultclient.go
@@ -108,13 +108,6 @@ func (c *defaultClient) fetchYAMLOrJSON(url string, target any) error {
 		}
 	}
 
-	if cached.updated.Add(c.maxCacheAge).After(time.Now()) {
-		if c.debug {
-			fmt.Fprintln(os.Stderr, "cache hit", url)
-		}
-		return yaml.Unmarshal(cached.bytes, target)
-	}
-
 	cached.mutex.Lock()
 	defer cached.mutex.Unlock()
 


### PR DESCRIPTION
## 📑 Description
This PR fixes the following data race detected by running the UI with the `-race` flag:
```
==================
WARNING: DATA RACE
Write at 0x00c000654618 by goroutine 164:
  github.com/glasskube/glasskube/internal/repo/client.(*defaultClient).fetchYAMLOrJSON()
      /home/kosmoz/Development/glasskube-pm/internal/repo/client/defaultclient.go:153 +0xde4
  github.com/glasskube/glasskube/internal/repo/client.(*defaultClient).FetchPackageManifest()
      /home/kosmoz/Development/glasskube-pm/internal/repo/client/defaultclient.go:65 +0xa4
  github.com/glasskube/glasskube/pkg/describe.DescribeInstalledPackage()
      /home/kosmoz/Development/glasskube-pm/pkg/describe/describe.go:32 +0x355
  github.com/glasskube/glasskube/internal/web.(*server).packageDetail()
      /home/kosmoz/Development/glasskube-pm/internal/web/server.go:374 +0x184
  github.com/glasskube/glasskube/internal/web.(*server).packageDetail-fm()
      <autogenerated>:1 +0x51
  net/http.HandlerFunc.ServeHTTP()
      /home/kosmoz/.local/share/mise/installs/go/1.22.3/src/net/http/server.go:2166 +0x47
  github.com/glasskube/glasskube/internal/web/handler.(*PreconditionHandler).ServeHTTP()
      /home/kosmoz/Development/glasskube-pm/internal/web/handler/precondition.go:18 +0xd0
  github.com/glasskube/glasskube/internal/web.(*server).Start.HttpMiddleware.func2.1()
      /home/kosmoz/Development/glasskube-pm/internal/telemetry/client.go:221 +0x8f
  net/http.HandlerFunc.ServeHTTP()
      /home/kosmoz/.local/share/mise/installs/go/1.22.3/src/net/http/server.go:2166 +0x47
  github.com/gorilla/mux.(*Router).ServeHTTP()
      /home/kosmoz/Development/go/pkg/mod/github.com/gorilla/mux@v1.8.1/mux.go:212 +0x371
  github.com/glasskube/glasskube/internal/web/handler.(*ContextEnrichingHandler).ServeHTTP()
      /home/kosmoz/Development/glasskube-pm/internal/web/handler/enricher.go:35 +0x329
  net/http.(*ServeMux).ServeHTTP()
      /home/kosmoz/.local/share/mise/installs/go/1.22.3/src/net/http/server.go:2683 +0x1ef
  net/http.serverHandler.ServeHTTP()
      /home/kosmoz/.local/share/mise/installs/go/1.22.3/src/net/http/server.go:3137 +0x2a1
  net/http.(*conn).serve()
      /home/kosmoz/.local/share/mise/installs/go/1.22.3/src/net/http/server.go:2039 +0x13c4
  net/http.(*Server).Serve.gowrap3()
      /home/kosmoz/.local/share/mise/installs/go/1.22.3/src/net/http/server.go:3285 +0x4f

Previous read at 0x00c000654618 by goroutine 170:
  github.com/glasskube/glasskube/internal/repo/client.(*defaultClient).fetchYAMLOrJSON()
      /home/kosmoz/Development/glasskube-pm/internal/repo/client/defaultclient.go:111 +0x1e5
  github.com/glasskube/glasskube/internal/repo/client.(*defaultClient).FetchPackageManifest()
      /home/kosmoz/Development/glasskube-pm/internal/repo/client/defaultclient.go:65 +0xa4
  github.com/glasskube/glasskube/pkg/describe.DescribeInstalledPackage()
      /home/kosmoz/Development/glasskube-pm/pkg/describe/describe.go:32 +0x355
  github.com/glasskube/glasskube/internal/web.(*server).packageDetail()
      /home/kosmoz/Development/glasskube-pm/internal/web/server.go:374 +0x184
  github.com/glasskube/glasskube/internal/web.(*server).packageDetail-fm()
      <autogenerated>:1 +0x51
  net/http.HandlerFunc.ServeHTTP()
      /home/kosmoz/.local/share/mise/installs/go/1.22.3/src/net/http/server.go:2166 +0x47
  github.com/glasskube/glasskube/internal/web/handler.(*PreconditionHandler).ServeHTTP()
      /home/kosmoz/Development/glasskube-pm/internal/web/handler/precondition.go:18 +0xd0
  github.com/glasskube/glasskube/internal/web.(*server).Start.HttpMiddleware.func2.1()
      /home/kosmoz/Development/glasskube-pm/internal/telemetry/client.go:221 +0x8f
  net/http.HandlerFunc.ServeHTTP()
      /home/kosmoz/.local/share/mise/installs/go/1.22.3/src/net/http/server.go:2166 +0x47
  github.com/gorilla/mux.(*Router).ServeHTTP()
      /home/kosmoz/Development/go/pkg/mod/github.com/gorilla/mux@v1.8.1/mux.go:212 +0x371
  github.com/glasskube/glasskube/internal/web/handler.(*ContextEnrichingHandler).ServeHTTP()
      /home/kosmoz/Development/glasskube-pm/internal/web/handler/enricher.go:35 +0x329
  net/http.(*ServeMux).ServeHTTP()
      /home/kosmoz/.local/share/mise/installs/go/1.22.3/src/net/http/server.go:2683 +0x1ef
  net/http.serverHandler.ServeHTTP()
      /home/kosmoz/.local/share/mise/installs/go/1.22.3/src/net/http/server.go:3137 +0x2a1
  net/http.(*conn).serve()
      /home/kosmoz/.local/share/mise/installs/go/1.22.3/src/net/http/server.go:2039 +0x13c4
  net/http.(*Server).Serve.gowrap3()
      /home/kosmoz/.local/share/mise/installs/go/1.22.3/src/net/http/server.go:3285 +0x4f

Goroutine 164 (running) created at:
  net/http.(*Server).Serve()
      /home/kosmoz/.local/share/mise/installs/go/1.22.3/src/net/http/server.go:3285 +0x8ec
  github.com/glasskube/glasskube/internal/web.(*server).Start()
      /home/kosmoz/Development/glasskube-pm/internal/web/server.go:215 +0x30e4
  github.com/glasskube/glasskube/cmd/glasskube/cmd.init.func10()
      /home/kosmoz/Development/glasskube-pm/cmd/glasskube/cmd/serve.go:31 +0x29a
  github.com/spf13/cobra.(*Command).execute()
      /home/kosmoz/Development/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:987 +0x1185
  github.com/spf13/cobra.(*Command).ExecuteC()
      /home/kosmoz/Development/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x657
  github.com/spf13/cobra.(*Command).Execute()
      /home/kosmoz/Development/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039 +0x26
  main.main()
      /home/kosmoz/Development/glasskube-pm/cmd/glasskube/main.go:11 +0x27

Goroutine 170 (running) created at:
  net/http.(*Server).Serve()
      /home/kosmoz/.local/share/mise/installs/go/1.22.3/src/net/http/server.go:3285 +0x8ec
  github.com/glasskube/glasskube/internal/web.(*server).Start()
      /home/kosmoz/Development/glasskube-pm/internal/web/server.go:215 +0x30e4
  github.com/glasskube/glasskube/cmd/glasskube/cmd.init.func10()
      /home/kosmoz/Development/glasskube-pm/cmd/glasskube/cmd/serve.go:31 +0x29a
  github.com/spf13/cobra.(*Command).execute()
      /home/kosmoz/Development/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:987 +0x1185
  github.com/spf13/cobra.(*Command).ExecuteC()
      /home/kosmoz/Development/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x657
  github.com/spf13/cobra.(*Command).Execute()
      /home/kosmoz/Development/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039 +0x26
  main.main()
      /home/kosmoz/Development/glasskube-pm/cmd/glasskube/main.go:11 +0x27
==================
```

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->