### PR TITLE
feat(cli): change flag from --force to --yes for glasskube uninstall

### DIFF
--- a/cmd/glasskube/cmd/uninstall.go
+++ b/cmd/glasskube/cmd/uninstall.go
@@ -14,8 +14,8 @@ import (
 )
 
 var uninstallCmdOptions = struct {
-	ForceUninstall bool
-	NoWait         bool
+	NoWait bool
+	Yes    bool
 }{}
 
 var uninstallCmd = &cobra.Command{
@@ -43,7 +43,7 @@ var uninstallCmd = &cobra.Command{
 				cliutils.ExitWithError()
 			} else {
 				showUninstallDetails(currentContext, pkgName, pruned)
-				if !uninstallCmdOptions.ForceUninstall && !cliutils.YesNoPrompt("Do you want to continue?", false) {
+				if !uninstallCmdOptions.Yes && !cliutils.YesNoPrompt("Do you want to continue?", false) {
 					fmt.Println("❌ Uninstallation cancelled.")
 					cliutils.ExitSuccess()
 				}
@@ -84,8 +84,9 @@ func showUninstallDetails(context, name string, pruned []string) {
 }
 
 func init() {
-	uninstallCmd.PersistentFlags().BoolVar(&uninstallCmdOptions.ForceUninstall, "force", false,
-		"skip the confirmation question and uninstall right away")
-	uninstallCmd.PersistentFlags().BoolVar(&uninstallCmdOptions.NoWait, "no-wait", false, "perform non-blocking uninstall")
+	uninstallCmd.PersistentFlags().BoolVar(&uninstallCmdOptions.NoWait, "no-wait", false,
+		"perform non-blocking uninstall")
+	uninstallCmd.PersistentFlags().BoolVarP(&uninstallCmdOptions.Yes, "yes", "y", false,
+		"do not ask for any confirmation")
 	RootCmd.AddCommand(uninstallCmd)
 }


### PR DESCRIPTION
Closes #760

## 📑 Description

This PR changes flag name of --force to --yes for glasskube uninstall

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
This is a breaking change for the CLI as the --force flag is replaced with --yes for consistency. Here's a screenshot of the flags available for glasskube uninstall :

![image](https://github.com/glasskube/glasskube/assets/30386061/048c745a-b8c0-4392-96ae-13ba177e3d0d)

And here's the flag in action:

![image](https://github.com/glasskube/glasskube/assets/30386061/46f0e8f0-566f-4b6e-9665-d677a2e7e9dd)

As this is my first PR I hope I've followed the contributing guide (really nice guide) and don't hesitate to point me to any changes and improvements so I can create better PR for this cool project
