### PR TITLE
feat(cli): introduce `--skip-open` support for `glasskube serve`

### DIFF
--- a/cmd/glasskube/cmd/serve.go
+++ b/cmd/glasskube/cmd/serve.go
@@ -12,8 +12,9 @@ import (
 )
 
 var serveCmdOptions struct {
-	port     int
-	logLevel int
+	port        int
+	logLevel    int
+	skipOpenFlg bool
 }
 
 var serveCmd = &cobra.Command{
@@ -24,10 +25,11 @@ var serveCmd = &cobra.Command{
 	Args:    cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		options := web.ServerOptions{
-			Host:       "localhost",
-			Port:       int32(serveCmdOptions.port),
-			Kubeconfig: config.Kubeconfig,
-			LogLevel:   serveCmdOptions.logLevel,
+			Host:               "localhost",
+			Port:               int32(serveCmdOptions.port),
+			Kubeconfig:         config.Kubeconfig,
+			LogLevel:           serveCmdOptions.logLevel,
+			SkipOpeningBrowser: serveCmdOptions.skipOpenFlg,
 		}
 		server := web.NewServer(options)
 		if err := server.Start(cmd.Context()); err != nil {
@@ -41,5 +43,6 @@ func init() {
 	serveCmd.Flags().IntVarP(&serveCmdOptions.port, "port", "p", 8580, "Port for the webserver")
 	serveCmd.Flags().IntVarP(&serveCmdOptions.logLevel, "log-level", "l", 0,
 		"Level for additional logging, where 0 is the least verbose")
+	serveCmd.Flags().BoolVarP(&serveCmdOptions.skipOpenFlg, "skip-open", "s", false, "Skip opening the browser")
 	RootCmd.AddCommand(serveCmd)
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -77,10 +77,11 @@ func init() {
 }
 
 type ServerOptions struct {
-	Host       string
-	Port       int32
-	Kubeconfig string
-	LogLevel   int
+	Host               string
+	Port               int32
+	Kubeconfig         string
+	LogLevel           int
+	SkipOpeningBrowser bool
 }
 
 func NewServer(options ServerOptions) *server {
@@ -225,7 +226,9 @@ func (s *server) Start(ctx context.Context) error {
 	}
 
 	fmt.Printf("glasskube UI is available at http://%v\n", bindAddr)
-	_ = cliutils.OpenInBrowser("http://" + bindAddr)
+	if !s.SkipOpeningBrowser {
+		_ = cliutils.OpenInBrowser("http://" + bindAddr)
+	}
 
 	go s.sseHub.Run()
 	server := &http.Server{}


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #753  <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->
Introduce `--skip-open` support for `glasskube serve` to skip opening the browser.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->