### PR TITLE
feat(cli): add `--output` flag for `glasskube bootstrap`

### DIFF
--- a/cmd/glasskube/cmd/bootstrap.go
+++ b/cmd/glasskube/cmd/bootstrap.go
@@ -135,7 +135,7 @@ func convertAndPrintManifests(
 		}
 	case OutputFormatYAML:
 		for i, obj := range objs {
-			yamlData, err := yaml.Marshal(obj)
+			yamlData, err := yaml.Marshal(&obj)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "error marshaling data to YAML: %v\n", err)
 				cliutils.ExitWithError()

--- a/cmd/glasskube/cmd/bootstrap.go
+++ b/cmd/glasskube/cmd/bootstrap.go
@@ -90,7 +90,7 @@ var bootstrapCmd = &cobra.Command{
 			fmt.Fprintf(os.Stderr, "\nAn error occurred during bootstrap:\n%v\n", err)
 			cliutils.ExitWithError()
 		}
-		if err := bootstrapCmdOptions.printBootsrap(
+		if err := printBootsrap(
 			manifests,
 			bootstrapCmdOptions.Output,
 		); err != nil {
@@ -111,8 +111,8 @@ func (o bootstrapOptions) asBootstrapOptions() bootstrap.BootstrapOptions {
 	}
 }
 
-func (o bootstrapOptions) printBootsrap(manifests []unstructured.Unstructured, output OutputFormat) error {
-	if o.Output != "" {
+func printBootsrap(manifests []unstructured.Unstructured, output OutputFormat) error {
+	if output != "" {
 		if err := convertAndPrintManifests(manifests, output); err != nil {
 			return err
 		}

--- a/cmd/glasskube/cmd/bootstrap.go
+++ b/cmd/glasskube/cmd/bootstrap.go
@@ -79,7 +79,11 @@ var bootstrapCmd = &cobra.Command{
 			}
 
 		}
-		if err := client.Bootstrap(cmd.Context(), bootstrapCmdOptions.asBootstrapOptions(), bootstrapCmdOptions.Output.String()); err != nil {
+		if err := client.Bootstrap(
+			cmd.Context(),
+			bootstrapCmdOptions.asBootstrapOptions(),
+			bootstrapCmdOptions.Output.String(),
+		); err != nil {
 			fmt.Fprintf(os.Stderr, "\nAn error occurred during bootstrap:\n%v\n", err)
 			cliutils.ExitWithError()
 

--- a/cmd/glasskube/cmd/bootstrap.go
+++ b/cmd/glasskube/cmd/bootstrap.go
@@ -22,6 +22,7 @@ type bootstrapOptions struct {
 	force                   bool
 	createDefaultRepository bool
 	yes                     bool
+	OutputOptions
 }
 
 var bootstrapCmdOptions = bootstrapOptions{
@@ -78,10 +79,10 @@ var bootstrapCmd = &cobra.Command{
 			}
 
 		}
-
-		if err := client.Bootstrap(cmd.Context(), bootstrapCmdOptions.asBootstrapOptions()); err != nil {
+		if err := client.Bootstrap(cmd.Context(), bootstrapCmdOptions.asBootstrapOptions(), bootstrapCmdOptions.Output.String()); err != nil {
 			fmt.Fprintf(os.Stderr, "\nAn error occurred during bootstrap:\n%v\n", err)
 			cliutils.ExitWithError()
+
 		}
 	},
 }
@@ -103,6 +104,7 @@ func init() {
 	bootstrapCmd.Flags().VarP(&bootstrapCmdOptions.bootstrapType, "type", "t", `Type of manifest to use for bootstrapping`)
 	bootstrapCmd.Flags().BoolVar(&bootstrapCmdOptions.latest, "latest", config.IsDevBuild(),
 		"Fetch and bootstrap the latest version")
+	bootstrapCmdOptions.OutputOptions.AddFlagsToCommand(bootstrapCmd)
 	bootstrapCmd.Flags().BoolVarP(&bootstrapCmdOptions.force, "force", "f", bootstrapCmdOptions.force,
 		"Do not bail out if pre-checks fail")
 	bootstrapCmd.Flags().BoolVar(&bootstrapCmdOptions.disableTelemetry, "disable-telemetry", false, "Disable telemetry")

--- a/cmd/glasskube/cmd/bootstrap.go
+++ b/cmd/glasskube/cmd/bootstrap.go
@@ -94,7 +94,7 @@ var bootstrapCmd = &cobra.Command{
 			manifests,
 			bootstrapCmdOptions.Output,
 		); err != nil {
-			fmt.Fprintf(os.Stderr, "\nAn error occured in printing : %v\n", err)
+			fmt.Fprintf(os.Stderr, "\nAn error occurred in printing : %v\n", err)
 			cliutils.ExitWithError()
 		}
 	},

--- a/internal/cliutils/setupclientcontext.go
+++ b/internal/cliutils/setupclientcontext.go
@@ -63,7 +63,7 @@ func RequireBootstrapped(ctx context.Context, cfg *rest.Config, rawCfg *api.Conf
 			ExitWithError()
 		}
 		client := bootstrap.NewBootstrapClient(cfg)
-		if err := client.Bootstrap(ctx, bootstrap.DefaultOptions()); err != nil {
+		if err := client.Bootstrap(ctx, bootstrap.DefaultOptions(), ""); err != nil {
 			fmt.Fprintf(os.Stderr, "\nAn error occurred during bootstrap:\n%v\n", err)
 			ExitWithError()
 		} else {

--- a/internal/cliutils/setupclientcontext.go
+++ b/internal/cliutils/setupclientcontext.go
@@ -63,7 +63,7 @@ func RequireBootstrapped(ctx context.Context, cfg *rest.Config, rawCfg *api.Conf
 			ExitWithError()
 		}
 		client := bootstrap.NewBootstrapClient(cfg)
-		if err := client.Bootstrap(ctx, bootstrap.DefaultOptions(), ""); err != nil {
+		if _, err := client.Bootstrap(ctx, bootstrap.DefaultOptions()); err != nil {
 			fmt.Fprintf(os.Stderr, "\nAn error occurred during bootstrap:\n%v\n", err)
 			ExitWithError()
 		} else {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -713,7 +713,7 @@ func (s *server) bootstrapPage(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	if r.Method == "POST" {
 		client := bootstrap.NewBootstrapClient(s.restConfig)
-		if err := client.Bootstrap(ctx, bootstrap.DefaultOptions()); err != nil {
+		if err := client.Bootstrap(ctx, bootstrap.DefaultOptions(), ""); err != nil {
 			fmt.Fprintf(os.Stderr, "\nAn error occurred during bootstrap:\n%v\n", err)
 			err := s.templates.bootstrapPageTmpl.ExecuteTemplate(w, "bootstrap-failure", nil)
 			checkTmplError(err, "bootstrap-failure")

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -713,7 +713,7 @@ func (s *server) bootstrapPage(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	if r.Method == "POST" {
 		client := bootstrap.NewBootstrapClient(s.restConfig)
-		if err := client.Bootstrap(ctx, bootstrap.DefaultOptions(), ""); err != nil {
+		if _, err := client.Bootstrap(ctx, bootstrap.DefaultOptions()); err != nil {
 			fmt.Fprintf(os.Stderr, "\nAn error occurred during bootstrap:\n%v\n", err)
 			err := s.templates.bootstrapPageTmpl.ExecuteTemplate(w, "bootstrap-failure", nil)
 			checkTmplError(err, "bootstrap-failure")

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -145,7 +145,9 @@ func (c *BootstrapClient) Bootstrap(ctx context.Context, options BootstrapOption
 
 	statusMessage(fmt.Sprintf("Glasskube successfully installed! (took %v)", elapsed.Round(time.Second)), true)
 	if output != "" {
-		convertAndPrintManifests(manifests, output)
+		if err := convertAndPrintManifests(manifests, output); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/fatih/color"
@@ -86,7 +87,7 @@ func (c *BootstrapClient) Bootstrap(
 		c.client = client
 	}
 
-	fmt.Println(installMessage)
+	fmt.Fprintln(os.Stderr, installMessage)
 	start := time.Now()
 
 	if options.Url == "" {
@@ -359,9 +360,9 @@ func (c *BootstrapClient) checkWorkloadReady(
 func statusMessage(input string, success bool) {
 	if success {
 		green := color.New(color.FgGreen).SprintFunc()
-		fmt.Println(green("* " + input))
+		fmt.Fprintln(os.Stderr, green("* "+input))
 	} else {
 		red := color.New(color.FgRed).SprintFunc()
-		fmt.Println(red("* " + input))
+		fmt.Fprintln(os.Stderr, red("* "+input))
 	}
 }

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -70,7 +70,10 @@ func (c *BootstrapClient) initRestMapper() error {
 	}
 }
 
-func (c *BootstrapClient) Bootstrap(ctx context.Context, options BootstrapOptions) ([]unstructured.Unstructured, error) {
+func (c *BootstrapClient) Bootstrap(
+	ctx context.Context,
+	options BootstrapOptions,
+) ([]unstructured.Unstructured, error) {
 	telemetry.BootstrapAttempt()
 
 	if err := c.initRestMapper(); err != nil {


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #724 
Fixes #724 

## 📑 Description
This PR adds the feature for receiving JSON/YAML output for bootstrap command. This gives an output of all the Kubernetes Resources that are changed. 

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Working
1. Give a bootstrap command with the flags `-o` add YAML or JSON to it
2. Now it will first bootstrap the cluster as it will normally do (unless an error occurs)
3. After the bootstrap is completed successfully it will show all the changed Resources in the format you gave in.
something like this:

```
## Installing GLASSKUBE ##
≡ƒºè The next generation Package Manager for Kubernetes ≡ƒôª
* Fetching Glasskube manifest from https://github.com/glasskube/glasskube/releases/download/v0.8.0/manifest-aio.yaml
* Validating existing installation
* Applying Glasskube manifests
* Telemetry is enabled for this cluster ΓÇô Run "glasskube telemetry status" for more info.
* Glasskube successfully installed! (took 22s)
apiVersion: v1
kind: Namespace
metadata:
  name: flux-system
---
apiVersion: v1
kind: Namespace
metadata:
  annotations:
    packages.glasskube.dev/telemetry-enabled: "true"
    packages.glasskube.dev/telemetry-id: b753e233-32ac-47eb-a25b-299b74094587
  labels:
    app.kubernetes.io/component: manager
    app.kubernetes.io/created-by: glasskube
    app.kubernetes.io/instance: system
    app.kubernetes.io/managed-by: kustomize
    app.kubernetes.io/name: namespace
    app.kubernetes.io/part-of: glasskube
    control-plane: controller-manager
  name: glasskube-system
---
apiVersion: v1
kind: ResourceQuota
metadata:
  name: critical-pods
  namespace: flux-system
spec:
  hard:
    pods: "1000"
  scopeSelector:
    matchExpressions:
    - operator: In
      scopeName: PriorityClass
      values:
      - system-node-critical
      - system-cluster-critical
---

// Rest all Resources/Objects
```