### PR TITLE
fix(ui): suppress 404 error for packages w/o a giscus discussion

### DIFF
--- a/internal/httperror/error.go
+++ b/internal/httperror/error.go
@@ -24,8 +24,8 @@ func (err statusError) Unwrap() error {
 	return StatusError
 }
 
-func IsErrorResponse(respose *http.Response) bool {
-	return respose.StatusCode >= 400
+func IsErrorResponse(response *http.Response) bool {
+	return response.StatusCode >= 400
 }
 
 func CheckResponse(response *http.Response, err error) (*http.Response, error) {
@@ -39,10 +39,9 @@ func CheckResponse(response *http.Response, err error) (*http.Response, error) {
 }
 
 func Is(err error, code int) bool {
-	var statusErr statusError
+	var statusErr *statusError
 	if errors.As(err, &statusErr) {
 		return statusErr.code == code
-
 	}
 	return false
 }

--- a/internal/web/discussions.go
+++ b/internal/web/discussions.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/glasskube/glasskube/internal/giscus"
+	"github.com/glasskube/glasskube/internal/httperror"
 
 	"github.com/glasskube/glasskube/api/v1alpha1"
 	"github.com/glasskube/glasskube/internal/repo"
@@ -69,7 +70,9 @@ func (s *server) discussionBadge(w http.ResponseWriter, r *http.Request) {
 
 	var totalCount int
 	if counts, err := giscus.Client().GetCountsFor(pkgName); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to get discussion counts from giscus: %v\n", err)
+		if !httperror.IsNotFound(err) {
+			fmt.Fprintf(os.Stderr, "failed to get discussion counts from giscus: %v\n", err)
+		}
 	} else {
 		totalCount = counts.ReactionCount + counts.TotalCommentCount + counts.TotalReplyCount
 	}


### PR DESCRIPTION
Closes #755 

## 📑 Description
This PR suppress the `failed to get discussion counts from giscus: wrong status code: 404 Not Found` message from the command line if we get a 404 calling gitcus API. Also this PR fixes an issue with the Is function found in the httperror package

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information

My intention was to use the httperror.IsNotFound function to suppress the message, but I was having a problem with that function as it always returned false if I tested to get a package with no discussion. I debugged the httperrors.IsNotFound function and it seems that httperrors.Is had an issue. I've changed `var statusErr statusError`

```
func Is(err error, code int) bool {
	var statusErr *statusError  <----
	if errors.As(err, &statusErr) {
		return statusErr.code == code
	}
	return false
}
```

I think that statusError must be a pointer as shown in the errors.As example: https://pkg.go.dev/errors#example-As. Indeed if I debug with VSCode, if I don't use the pointer errors.As cannot find a statusError in the tree and it always evaluates to false

![image](https://github.com/glasskube/glasskube/assets/30386061/4fabeb79-2a16-4e78-87fd-f8cbb714fea7)

But if I use the pointer, the statusError is found in the error tree and evaluation works fine:

![image](https://github.com/glasskube/glasskube/assets/30386061/d2dfd507-0a42-4189-a000-fbb496637a24)

Also I've fixed a var name typo

Hope I've explained the issue. As it was a small change related with the main change for the issue I feel it wasn't necessary to open a different issue, but it you want me to open a different issue just let me know. Thanks!