### PR TITLE
fix(cli): `repo add --default` removes annotation for current default repo

### DIFF
--- a/internal/cliutils/packagerepository.go
+++ b/internal/cliutils/packagerepository.go
@@ -7,6 +7,8 @@ import (
 	"github.com/glasskube/glasskube/api/v1alpha1"
 )
 
+var NoDefaultRepo = fmt.Errorf("no default repo was found")
+
 func GetDefaultRepo(ctx context.Context) (*v1alpha1.PackageRepository, error) {
 	var repos v1alpha1.PackageRepositoryList
 
@@ -21,5 +23,5 @@ func GetDefaultRepo(ctx context.Context) (*v1alpha1.PackageRepository, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("no default repo was found")
+	return nil, NoDefaultRepo
 }

--- a/website/docs/04_design/repositories.md
+++ b/website/docs/04_design/repositories.md
@@ -85,7 +85,8 @@ Installed packages do not break but can not be updated until the missing reposit
 
 - `glasskube repo list` prints a list of installed repositories
 - `glasskube repo add [name] [url]` creates a new repository
-  - `--default` toggles the `packages.glasskube.dev/defaultRepository=true` annotation
+  - `--default` toggles the `packages.glasskube.dev/defaultRepository=true` annotation. If there is a repository
+    with that annotation already, the default annotation will be removed for that repository
   - `--auth=none` no authentication (default)
   - `--auth=basic` enables basic authentication
   - `--auth=bearer` enables token authentication


### PR DESCRIPTION
Closes #806 

## 📑 Description

This PR changes `repo add --default` so we can only have one default repository

## ✅ Checks
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required

## ℹ Additional Information

If we now add a new repo using the --default flag we can have two or more repositories with the default annotation set. With this PR the command updates the current default repo to remove the default annotation so we only have one default repository. If we've an error when adding the new repo we roll back and set the default annotation for the previous repo.