### PR TITLE
fix(ui): open package description links in new tab

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/yuin/goldmark v1.7.2
 	go.uber.org/multierr v1.11.0
+	golang.org/x/net v0.25.0
 	golang.org/x/term v0.21.0
 	k8s.io/api v0.30.2
 	k8s.io/apiextensions-apiserver v0.30.2
@@ -83,7 +84,6 @@ require (
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	go.uber.org/zap v1.26.0 // indirect
 	golang.org/x/exp v0.0.0-20240112132812-db7319d0e0e3 // indirect
-	golang.org/x/net v0.25.0 // indirect
 	golang.org/x/oauth2 v0.16.0 // indirect
 	golang.org/x/sys v0.21.0 // indirect
 	golang.org/x/text v0.15.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/yuin/goldmark v1.7.2
 	go.uber.org/multierr v1.11.0
-	golang.org/x/net v0.25.0
 	golang.org/x/term v0.21.0
 	k8s.io/api v0.30.2
 	k8s.io/apiextensions-apiserver v0.30.2
@@ -84,6 +83,7 @@ require (
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	go.uber.org/zap v1.26.0 // indirect
 	golang.org/x/exp v0.0.0-20240112132812-db7319d0e0e3 // indirect
+	golang.org/x/net v0.25.0 // indirect
 	golang.org/x/oauth2 v0.16.0 // indirect
 	golang.org/x/sys v0.21.0 // indirect
 	golang.org/x/text v0.15.0 // indirect


### PR DESCRIPTION
Closes #832 

## 📑 Description

This PR makes links in package description open in a new tab: `target="_blank" rel="noopener noreferrer"`

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information

This PR uses https://pkg.go.dev/golang.org/x/net/html to parse the html and manipulate the nodes to add the target and rel attributes to any link found in the converted markdown. Here's a vide showing the new behavior:

https://github.com/glasskube/glasskube/assets/30386061/fbb2c376-ceaf-45f4-a9f7-b96aaac58c2e


