### PR TITLE
fix(client): propagate list options and apply timeout

### DIFF
--- a/pkg/client/client_cached.go
+++ b/pkg/client/client_cached.go
@@ -72,8 +72,8 @@ type readOnlyCacheClient[T any, L any] struct {
 	listFactory func(items []T) L
 }
 
-func (c *readOnlyCacheClient[T, L]) Watch(ctx context.Context) (watch.Interface, error) {
-	return c.fallback.Watch(ctx)
+func (c *readOnlyCacheClient[T, L]) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	return c.fallback.Watch(ctx, opts)
 }
 
 func (c *readOnlyCacheClient[T, L]) Get(ctx context.Context, name string, target *T) error {

--- a/pkg/client/cluster_package.go
+++ b/pkg/client/cluster_package.go
@@ -3,6 +3,7 @@ package client
 
 import (
 	"context"
+	"time"
 
 	"github.com/glasskube/glasskube/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,10 +36,15 @@ func (c *clusterPackageClient) Update(ctx context.Context, p *v1alpha1.ClusterPa
 		Into(p)
 }
 
-func (c *clusterPackageClient) Watch(ctx context.Context) (watch.Interface, error) {
-	opts := metav1.ListOptions{Watch: true}
+func (c *clusterPackageClient) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	var timeout time.Duration
+	if opts.TimeoutSeconds != nil {
+		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	}
+	opts.Watch = true
 	return c.restClient.Get().
 		Resource(clusterPackageGVR.Resource).
+		Timeout(timeout).
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Watch(ctx)
 }

--- a/pkg/client/interface.go
+++ b/pkg/client/interface.go
@@ -40,7 +40,7 @@ type PackageRepositoryInterface interface {
 type readOnlyClientInterface[T any, L any] interface {
 	Get(ctx context.Context, name string, target *T) error
 	GetAll(ctx context.Context, target *L) error
-	Watch(ctx context.Context) (watch.Interface, error)
+	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
 }
 
 type readWriteClientInterface[T any, L any] interface {

--- a/pkg/client/package.go
+++ b/pkg/client/package.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"time"
 
 	"github.com/glasskube/glasskube/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -66,11 +67,16 @@ func (p *packageClient) Update(ctx context.Context, target *v1alpha1.Package) er
 }
 
 // Watch implements PackageInterface.
-func (p *packageClient) Watch(ctx context.Context) (watch.Interface, error) {
-	opts := metav1.ListOptions{Watch: true}
+func (p *packageClient) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	var timeout time.Duration
+	if opts.TimeoutSeconds != nil {
+		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	}
+	opts.Watch = true
 	return p.restClient.Get().
 		Namespace(p.ns).
 		Resource(packagesResource).
+		Timeout(timeout).
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Watch(ctx)
 }

--- a/pkg/client/packageinfo.go
+++ b/pkg/client/packageinfo.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
@@ -33,10 +34,15 @@ func (c *packageInfoClient) Get(ctx context.Context, name string, packageInfo *v
 		Into(packageInfo)
 }
 
-func (c *packageInfoClient) Watch(ctx context.Context) (watch.Interface, error) {
-	opts := metav1.ListOptions{Watch: true}
+func (c *packageInfoClient) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	var timeout time.Duration
+	if opts.TimeoutSeconds != nil {
+		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	}
+	opts.Watch = true
 	return c.restClient.Get().
 		Resource(packageInfoGVR.Resource).
+		Timeout(timeout).
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Watch(ctx)
 }

--- a/pkg/client/packagerepository.go
+++ b/pkg/client/packagerepository.go
@@ -3,6 +3,7 @@ package client
 
 import (
 	"context"
+	"time"
 
 	"github.com/glasskube/glasskube/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,10 +41,15 @@ func (c *packageRepositoryClient) Update(ctx context.Context, obj *v1alpha1.Pack
 }
 
 // Watch implements PackageRepositoryInterface.
-func (c *packageRepositoryClient) Watch(ctx context.Context) (watch.Interface, error) {
-	opts := metav1.ListOptions{Watch: true}
+func (c *packageRepositoryClient) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	var timeout time.Duration
+	if opts.TimeoutSeconds != nil {
+		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	}
+	opts.Watch = true
 	return c.restClient.Get().
 		Resource(packageRepositoryGVR.Resource).
+		Timeout(timeout).
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Watch(ctx)
 }

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -75,7 +75,7 @@ func (obj *installer) install(
 }
 
 func (obj *installer) awaitInstall(ctx context.Context, pkgUID types.UID) (*client.PackageStatus, error) {
-	watcher, err := obj.client.ClusterPackages().Watch(ctx)
+	watcher, err := obj.client.ClusterPackages().Watch(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/uninstall/uninstall.go
+++ b/pkg/uninstall/uninstall.go
@@ -54,7 +54,7 @@ func (obj *uninstaller) delete(ctx context.Context, pkg *v1alpha1.ClusterPackage
 }
 
 func (obj *uninstaller) awaitDeletion(ctx context.Context, name string) error {
-	watcher, err := obj.client.ClusterPackages().Watch(ctx)
+	watcher, err := obj.client.ClusterPackages().Watch(ctx, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -202,7 +202,7 @@ func (c *updater) UpdatePackage(ctx context.Context, pkg *v1alpha1.ClusterPackag
 }
 
 func (c *updater) awaitUpdate(ctx context.Context, pkg *v1alpha1.ClusterPackage) error {
-	watcher, err := c.client.ClusterPackages().Watch(ctx)
+	watcher, err := c.client.ClusterPackages().Watch(ctx, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Ref #838 

## 📑 Description
This is an attempt at making the out of sync problem less likely to happen, by passing a fixed timeout in the API call (like also all standard listers for namespace, secrets, etc do). The "base" timeout is set by the lister/watcher of the go client, but we divide it by 10 to "force" rewatches in smaller iterations. This should lead to re-watches every 30 - 60 seconds, so even if the out of sync issue appears, it would hopefully repair itself after at latest 1 minute. 

Additionally, by passing the given list options to our client, and reusing it rather than overwriting it, we will set the `allowWatchBookmarks` flag to true. Therefore we will also process `BOOKMARK` events, which might have an influence on the issue: https://stackoverflow.com/questions/66080942/what-k8s-bookmark-solves

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information