### PR TITLE
fix(cli): standardize usage texts

### DIFF
--- a/cmd/glasskube/cmd/configure.go
+++ b/cmd/glasskube/cmd/configure.go
@@ -27,7 +27,7 @@ var configureCmdOptions = struct {
 }
 
 var configureCmd = &cobra.Command{
-	Use:               "configure [package-name]",
+	Use:               "configure <package-name>",
 	Short:             "Configure a package",
 	Args:              cobra.ExactArgs(1),
 	PreRun:            cliutils.SetupClientContext(true, &rootCmdOptions.SkipUpdateCheck),

--- a/cmd/glasskube/cmd/describe.go
+++ b/cmd/glasskube/cmd/describe.go
@@ -33,7 +33,7 @@ var describeCmdOptions = struct {
 }{}
 
 var describeCmd = &cobra.Command{
-	Use:               "describe [package-name]",
+	Use:               "describe <package-name>",
 	Short:             "Describe a package",
 	Long:              "Shows additional information about the given package.",
 	Args:              cobra.ExactArgs(1),

--- a/cmd/glasskube/cmd/install.go
+++ b/cmd/glasskube/cmd/install.go
@@ -44,7 +44,7 @@ var installCmdOptions = struct {
 }
 
 var installCmd = &cobra.Command{
-	Use:               "install [package-name]",
+	Use:               "install <package-name>",
 	Short:             "Install a package",
 	Long:              `Install a package.`,
 	Args:              cobra.ExactArgs(1),

--- a/cmd/glasskube/cmd/kind_options.go
+++ b/cmd/glasskube/cmd/kind_options.go
@@ -39,7 +39,7 @@ func (kind *ResourceKind) String() string {
 
 // Type implements pflag.Value.
 func (r *ResourceKind) Type() string {
-	return fmt.Sprintf("[%v|%v]", KindPackage, KindClusterPackage)
+	return fmt.Sprintf("(%v|%v)", KindPackage, KindClusterPackage)
 }
 
 type KindOptions struct {

--- a/cmd/glasskube/cmd/open.go
+++ b/cmd/glasskube/cmd/open.go
@@ -24,7 +24,7 @@ var (
 )
 
 var openCmd = &cobra.Command{
-	Use:   "open [package-name] [entrypoint]",
+	Use:   "open <package-name> [<entrypoint>]",
 	Short: "Open the Web UI of a package",
 	Long: `Open the Web UI of a package.
 If the package manifest has more than one entrypoint, specify the name of the entrypoint to open.`,

--- a/cmd/glasskube/cmd/output_options.go
+++ b/cmd/glasskube/cmd/output_options.go
@@ -28,7 +28,7 @@ func (of *OutputFormat) Set(value string) error {
 }
 
 func (of *OutputFormat) Type() string {
-	return fmt.Sprintf("[%v|%v]", OutputFormatJSON, OutputFormatYAML)
+	return fmt.Sprintf("(%v|%v)", OutputFormatJSON, OutputFormatYAML)
 }
 
 type OutputOptions struct {

--- a/cmd/glasskube/cmd/repo_add.go
+++ b/cmd/glasskube/cmd/repo_add.go
@@ -14,7 +14,7 @@ import (
 var repoAddCmdOptions = repoOptions{}
 
 var repoAddCmd = &cobra.Command{
-	Use:    "add [name] [url]",
+	Use:    "add <name> <url>",
 	Short:  "Add a package repository to the current cluster",
 	Args:   cobra.ExactArgs(2),
 	PreRun: cliutils.SetupClientContext(true, &rootCmdOptions.SkipUpdateCheck),

--- a/cmd/glasskube/cmd/repo_options.go
+++ b/cmd/glasskube/cmd/repo_options.go
@@ -28,7 +28,7 @@ func (t *repoAuthType) Set(v string) error {
 }
 
 func (e *repoAuthType) Type() string {
-	return fmt.Sprintf("[%v|%v|%v]", repoNoAuth, repoBasicAuth, repoBearerAuth)
+	return fmt.Sprintf("(%v|%v|%v)", repoNoAuth, repoBasicAuth, repoBearerAuth)
 }
 
 const (

--- a/cmd/glasskube/cmd/repo_update.go
+++ b/cmd/glasskube/cmd/repo_update.go
@@ -13,7 +13,7 @@ import (
 var repoUpdateCmdOptions = repoOptions{}
 
 var repoUpdateCmd = &cobra.Command{
-	Use:    "update [name]",
+	Use:    "update <name>",
 	Short:  "Update a package repository for the current cluster",
 	Args:   cobra.ExactArgs(1),
 	PreRun: cliutils.SetupClientContext(true, &rootCmdOptions.SkipUpdateCheck),

--- a/cmd/glasskube/cmd/telemetry.go
+++ b/cmd/glasskube/cmd/telemetry.go
@@ -39,7 +39,7 @@ var telemetryStatusCmd = &cobra.Command{
 }
 
 var telemetryCmd = &cobra.Command{
-	Use:   "telemetry <enable|disable>",
+	Use:   "telemetry (enable|disable)",
 	Short: "View and modify telemetry settings",
 	Long: "View and modify telemetry settings. \n" +
 		"For more information on how Glasskube uses telemetry see https://glasskube.dev/telemetry",

--- a/cmd/glasskube/cmd/uninstall.go
+++ b/cmd/glasskube/cmd/uninstall.go
@@ -20,7 +20,7 @@ var uninstallCmdOptions = struct {
 }{}
 
 var uninstallCmd = &cobra.Command{
-	Use:               "uninstall [package-name]",
+	Use:               "uninstall <package-name>",
 	Short:             "Uninstall a package",
 	Long:              `Uninstall a package.`,
 	Args:              cobra.ExactArgs(1),

--- a/cmd/glasskube/cmd/update.go
+++ b/cmd/glasskube/cmd/update.go
@@ -31,7 +31,7 @@ var updateCmdOptions struct {
 }
 
 var updateCmd = &cobra.Command{
-	Use:               "update [packages...]",
+	Use:               "update [<package-name>...]",
 	Short:             "Update some or all packages in your cluster",
 	PreRun:            cliutils.SetupClientContext(true, &rootCmdOptions.SkipUpdateCheck),
 	ValidArgsFunction: completeInstalledPackageNames,

--- a/internal/manifestvalues/flags/flags.go
+++ b/internal/manifestvalues/flags/flags.go
@@ -39,7 +39,7 @@ func (opts *ValuesOptions) AddFlagsToCommand(cmd *cobra.Command) {
 	flags.StringArrayVar(&opts.Values, "value", opts.Values,
 		"set a value via flag (can be used multiple times).\n"+
 			"You can create values referencing data in other resources using the following syntax: "+
-			"$<ReferenceKind>$[specifier...].\n"+
+			"$<ReferenceKind>$[<specifier>[,<specifier>...]].\n"+
 			"For example:\n"+
 			" * Reference a ConfigMap key: --value \"name=$ConfigMapRef$namespace,name,key\"\n"+
 			" * Reference a Secret key: --value \"name=$SecretRef$namespace,name,key\"\n"+


### PR DESCRIPTION
## 📑 Description
We don't follow any rules when it comes to usage texts for the Glasskube CLI. This PR updates all usage texts and flag descriptions to follow the syntax described in http://docopt.org/

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->