### PR TITLE
feat(cli): add support for describing namespaced packages

### DIFF
--- a/cmd/glasskube/cmd/describe.go
+++ b/cmd/glasskube/cmd/describe.go
@@ -13,6 +13,7 @@ import (
 	"github.com/glasskube/glasskube/api/v1alpha1"
 	"github.com/glasskube/glasskube/internal/clientutils"
 	"github.com/glasskube/glasskube/internal/cliutils"
+	"github.com/glasskube/glasskube/internal/controller/ctrlpkg"
 	"github.com/glasskube/glasskube/internal/manifestvalues"
 	repoclient "github.com/glasskube/glasskube/internal/repo/client"
 	"github.com/glasskube/glasskube/internal/semver"
@@ -23,14 +24,18 @@ import (
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/renderer"
 	"github.com/yuin/goldmark/util"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/yaml"
 )
 
 var describeCmdOptions = struct {
 	repository string
 	OutputOptions
-}{}
+	KindOptions
+	NamespaceOptions
+}{
+	KindOptions: DefaultKindOptions(),
+}
 
 var describeCmd = &cobra.Command{
 	Use:               "describe <package-name>",
@@ -44,41 +49,104 @@ var describeCmd = &cobra.Command{
 		pkgName := args[0]
 		repoClient := cliutils.RepositoryClientset(ctx)
 
-		latestManifest, latestVersion, err :=
+		latestManifest, latestVersion, lvErr :=
 			describe.DescribeLatestVersion(ctx, describeCmdOptions.repository, pkgName)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "❌ Could not get latest info for %v: %v\n", pkgName, err)
-			cliutils.ExitWithError()
+		pkg, pkgErr :=
+			getPackageOrClusterPackage(ctx, pkgName, describeCmdOptions.KindOptions, describeCmdOptions.NamespaceOptions)
+
+		var manifest *v1alpha1.PackageManifest
+		var err error
+
+		if pkgErr != nil {
+			if errors.IsNotFound(pkgErr) {
+				// package not installed -> use latest manifest from repo
+				if lvErr != nil {
+					fmt.Fprintf(os.Stderr, "❌ Could not get latest info for %v: %v\n", pkgName, lvErr)
+					cliutils.ExitWithError()
+				}
+
+				manifest = latestManifest
+
+				// set p to a nil pointer with a concrete type so IsNil works correctly
+				if manifest.Scope.IsCluster() {
+					var p *v1alpha1.ClusterPackage
+					pkg = p
+				} else {
+					var p *v1alpha1.Package
+					pkg = p
+				}
+			} else {
+				// Unhandled error -> exit
+				fmt.Fprintf(os.Stderr, "❌ Could not get resource: %v\n", pkgErr)
+				cliutils.ExitWithError()
+			}
+		} else {
+			if manifest, err = describe.GetManifestForPkg(ctx, pkg); err != nil {
+				fmt.Fprintf(os.Stderr, "❌ Could not describe package %v: %v\n", pkgName, err)
+				cliutils.ExitWithError()
+			}
+			_, latestVersion, lvErr = describe.DescribeLatestVersion(ctx,
+				pkg.GetSpec().PackageInfo.RepositoryName,
+				pkg.GetSpec().PackageInfo.Name)
+			if lvErr != nil {
+				fmt.Fprintf(os.Stderr, "❌ Could not get latest version: %v\n", err)
+				cliutils.ExitWithError()
+			}
 		}
 
-		repos, err := repoClient.Meta().GetReposForPackage(pkgName)
+		// if pkgName refers to a namespace-scoped manifest and not an installed package, show something about every instance
+		var pkgs []v1alpha1.Package
+		if pkg.IsNil() && manifest.Scope.IsNamespaced() {
+			client := cliutils.PackageClient(ctx)
+			var pkgList v1alpha1.PackageList
+			if err := client.Packages(describeCmdOptions.Namespace).GetAll(ctx, &pkgList); err != nil {
+				fmt.Fprintf(os.Stderr, "❌ Could not list packages for %v: %v\n", pkgName, err)
+				cliutils.ExitWithError()
+			}
+			for _, pkg := range pkgList.Items {
+				if pkg.Spec.PackageInfo.Name == pkgName &&
+					(describeCmdOptions.repository == "" ||
+						pkg.Spec.PackageInfo.RepositoryName == describeCmdOptions.repository) {
+
+					pkgs = append(pkgs, pkg)
+				}
+			}
+		}
+
+		var repos []v1alpha1.PackageRepository
+		if pkg.IsNil() {
+			repos, err = repoClient.Meta().GetReposForPackage(pkgName)
+		} else {
+			repos, err = repoClient.Meta().GetReposForPackage(pkg.GetSpec().PackageInfo.Name)
+		}
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "❌ Could not get repos for %v: %v\n", pkgName, err)
 			cliutils.ExitWithError()
 		}
 
-		pkg, manifest, err := describe.DescribeInstalledClusterPackage(ctx, pkgName)
-		if err != nil && !apierrors.IsNotFound(err) {
-			// Unhandled error -> exit
-			fmt.Fprintf(os.Stderr, "❌ Could not describe package %v: %v\n", pkgName, err)
-			cliutils.ExitWithError()
-		} else if err != nil {
-			// package not installed -> use latest manifest from repo
-			manifest = latestManifest
-		}
-
 		bold := color.New(color.Bold).SprintFunc()
 
 		if describeCmdOptions.Output == OutputFormatJSON {
-			printJSON(ctx, pkg, manifest, latestVersion, repos)
+			printJSON(ctx, pkg, pkgs, manifest, latestVersion, repos)
 		} else if describeCmdOptions.Output == OutputFormatYAML {
-			printYAML(ctx, pkg, manifest, latestVersion, repos)
+			printYAML(ctx, pkg, pkgs, manifest, latestVersion, repos)
 		} else {
 			fmt.Println(bold("Package:"), nameAndDescription(manifest))
-			fmt.Println(bold("Version:"), version(pkg, latestVersion))
-			fmt.Println(bold("Status: "), status(pkg))
-			if pkg != nil {
+
+			if !pkg.IsNil() {
+				fmt.Println(bold("Version:    "), version(pkg, latestVersion))
+				fmt.Println(bold("Status:     "), status(pkg))
 				fmt.Println(bold("Auto-Update:"), clientutils.AutoUpdateString(pkg, "Disabled"))
+			} else if len(pkgs) > 0 {
+				fmt.Println()
+				fmt.Println(bold("Instances:"))
+				for i, pkg := range pkgs {
+					fmt.Println(fmt.Sprintf(" %v.", i+1), bold("Name:       "), pkg.Name)
+					fmt.Println(bold("    Namespace:  "), pkg.Namespace)
+					fmt.Println(bold("    Version:    "), version(&pkg, latestVersion))
+					fmt.Println(bold("    Status:     "), status(&pkg))
+					fmt.Println(bold("    Auto-Update:"), clientutils.AutoUpdateString(&pkg, "Disabled"))
+				}
 			}
 
 			if len(manifest.Entrypoints) > 0 {
@@ -108,10 +176,10 @@ var describeCmd = &cobra.Command{
 				printMarkdown(os.Stdout, trimmedDescription)
 			}
 
-			if pkg != nil && len(pkg.Spec.Values) > 0 {
+			if !pkg.IsNil() && len(pkg.GetSpec().Values) > 0 {
 				fmt.Println()
 				fmt.Println(bold("Configuration:"))
-				printValueConfigurations(os.Stdout, pkg.Spec.Values)
+				printValueConfigurations(os.Stdout, pkg.GetSpec().Values)
 			}
 		}
 	},
@@ -154,7 +222,7 @@ func printDependencies(manifest *v1alpha1.PackageManifest) {
 	}
 }
 
-func printRepositories(pkg *v1alpha1.ClusterPackage, repos []v1alpha1.PackageRepository) {
+func printRepositories(pkg ctrlpkg.Package, repos []v1alpha1.PackageRepository) {
 	for _, repo := range repos {
 		fmt.Fprintf(os.Stderr, " * %v", repo.Name)
 		if isInstalledFrom(pkg, repo) {
@@ -165,7 +233,7 @@ func printRepositories(pkg *v1alpha1.ClusterPackage, repos []v1alpha1.PackageRep
 	}
 }
 
-func repositoriesAsMap(pkg *v1alpha1.ClusterPackage, repos []v1alpha1.PackageRepository) []map[string]any {
+func repositoriesAsMap(pkg ctrlpkg.Package, repos []v1alpha1.PackageRepository) []map[string]any {
 	repositories := make([]map[string]any, 0, len(repos))
 	for _, repo := range repos {
 		repositories = append(repositories, map[string]any{
@@ -176,18 +244,18 @@ func repositoriesAsMap(pkg *v1alpha1.ClusterPackage, repos []v1alpha1.PackageRep
 	return repositories
 }
 
-func isInstalledFrom(pkg *v1alpha1.ClusterPackage, repo v1alpha1.PackageRepository) bool {
-	return pkg != nil &&
-		(repo.Name == pkg.Spec.PackageInfo.RepositoryName ||
-			(len(pkg.Spec.PackageInfo.RepositoryName) == 0 && repo.IsDefaultRepository()))
+func isInstalledFrom(pkg ctrlpkg.Package, repo v1alpha1.PackageRepository) bool {
+	return !pkg.IsNil() &&
+		(repo.Name == pkg.GetSpec().PackageInfo.RepositoryName ||
+			(len(pkg.GetSpec().PackageInfo.RepositoryName) == 0 && repo.IsDefaultRepository()))
 }
 
-func printReferences(ctx context.Context, pkg *v1alpha1.ClusterPackage, manifest *v1alpha1.PackageManifest) {
+func printReferences(ctx context.Context, pkg ctrlpkg.Package, manifest *v1alpha1.PackageManifest) {
 	repo := cliutils.RepositoryClientset(ctx)
 	var repoClient repoclient.RepoClient
-	if pkg != nil {
+	if !pkg.IsNil() {
 		repoClient = repo.ForPackage(pkg)
-		if url, err := repoClient.GetPackageManifestURL(manifest.Name, pkg.Spec.PackageInfo.Version); err != nil {
+		if url, err := repoClient.GetPackageManifestURL(manifest.Name, pkg.GetSpec().PackageInfo.Version); err != nil {
 			fmt.Fprintf(os.Stderr, "❌ Could not get package manifest url: %v\n", err)
 		} else {
 			fmt.Printf(" * Glasskube Package Manifest: %v\n", url)
@@ -200,7 +268,7 @@ func printReferences(ctx context.Context, pkg *v1alpha1.ClusterPackage, manifest
 
 func referencesAsMap(
 	ctx context.Context,
-	pkg *v1alpha1.ClusterPackage,
+	pkg ctrlpkg.Package,
 	manifest *v1alpha1.PackageManifest,
 ) []map[string]string {
 	references := []map[string]string{}
@@ -210,10 +278,10 @@ func referencesAsMap(
 		reference["url"] = ref.Url
 		references = append(references, reference)
 	}
-	if pkg != nil {
+	if !pkg.IsNil() {
 		repo := cliutils.RepositoryClientset(ctx)
 		repoClient := repo.ForPackage(pkg)
-		if url, err := repoClient.GetPackageManifestURL(manifest.Name, pkg.Spec.PackageInfo.Version); err == nil {
+		if url, err := repoClient.GetPackageManifestURL(manifest.Name, pkg.GetSpec().PackageInfo.Version); err == nil {
 			reference := make(map[string]string)
 			reference["label"] = "Glasskube Package Manifest"
 			reference["url"] = url
@@ -245,7 +313,7 @@ func printMarkdown(w io.Writer, text string) {
 	}
 }
 
-func status(pkg *v1alpha1.ClusterPackage) string {
+func status(pkg ctrlpkg.Package) string {
 	pkgStatus := client.GetStatusOrPending(pkg)
 	if pkgStatus != nil {
 		switch pkgStatus.Status {
@@ -261,16 +329,18 @@ func status(pkg *v1alpha1.ClusterPackage) string {
 	}
 }
 
-func version(pkg *v1alpha1.ClusterPackage, latestVersion string) string {
-	if pkg != nil {
+func version(pkg ctrlpkg.Package, latestVersion string) string {
+	if !pkg.IsNil() {
 		var parts []string
-		if len(pkg.Status.Version) > 0 {
-			parts = append(parts, pkg.Status.Version)
+		if len(pkg.GetStatus().Version) > 0 {
+			parts = append(parts, pkg.GetStatus().Version)
+		} else {
+			parts = append(parts, "n/a")
 		}
-		if pkg.Spec.PackageInfo.Version != pkg.Status.Version {
-			parts = append(parts, fmt.Sprintf("(desired: %v)", pkg.Spec.PackageInfo.Version))
+		if pkg.GetSpec().PackageInfo.Version != pkg.GetStatus().Version {
+			parts = append(parts, fmt.Sprintf("(desired: %v)", pkg.GetSpec().PackageInfo.Version))
 		}
-		if semver.IsUpgradable(pkg.Spec.PackageInfo.Version, latestVersion) {
+		if semver.IsUpgradable(pkg.GetSpec().PackageInfo.Version, latestVersion) {
 			parts = append(parts, fmt.Sprintf("(latest: %v)", latestVersion))
 		}
 		return strings.Join(parts, " ")
@@ -292,7 +362,8 @@ func nameAndDescription(manifest *v1alpha1.PackageManifest) string {
 
 func createOutputStructure(
 	ctx context.Context,
-	pkg *v1alpha1.ClusterPackage,
+	pkg ctrlpkg.Package,
+	instances []v1alpha1.Package,
 	manifest *v1alpha1.PackageManifest,
 	latestVersion string,
 	repos []v1alpha1.PackageRepository,
@@ -308,23 +379,27 @@ func createOutputStructure(
 		"repositories":     repositoriesAsMap(pkg, repos),
 		"references":       referencesAsMap(ctx, pkg, manifest),
 	}
-	if pkg != nil {
-		data["desiredVersion"] = pkg.Spec.PackageInfo.Version
-		data["configuration"] = pkg.Spec.Values
-		data["version"] = pkg.Status.Version
+	if !pkg.IsNil() {
+		data["desiredVersion"] = pkg.GetSpec().PackageInfo.Version
+		data["configuration"] = pkg.GetSpec().Values
+		data["version"] = pkg.GetStatus().Version
 		data["autoUpdate"] = pkg.AutoUpdatesEnabled()
-		data["isUpgradable"] = semver.IsUpgradable(pkg.Spec.PackageInfo.Version, latestVersion)
+		data["isUpgradable"] = semver.IsUpgradable(pkg.GetSpec().PackageInfo.Version, latestVersion)
 		data["status"] = client.GetStatusOrPending(pkg).Status
+	}
+	if len(instances) > 0 {
+		data["instances"] = instances
 	}
 	return data
 }
 
 func printJSON(ctx context.Context,
-	pkg *v1alpha1.ClusterPackage,
+	pkg ctrlpkg.Package,
+	pkgs []v1alpha1.Package,
 	manifest *v1alpha1.PackageManifest,
 	latestVersion string,
 	repos []v1alpha1.PackageRepository) {
-	output := createOutputStructure(ctx, pkg, manifest, latestVersion, repos)
+	output := createOutputStructure(ctx, pkg, pkgs, manifest, latestVersion, repos)
 	jsonOutput, err := json.MarshalIndent(output, "", "  ")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "❌ Could not marshal JSON output: %v\n", err)
@@ -334,11 +409,12 @@ func printJSON(ctx context.Context,
 }
 
 func printYAML(ctx context.Context,
-	pkg *v1alpha1.ClusterPackage,
+	pkg ctrlpkg.Package,
+	pkgs []v1alpha1.Package,
 	manifest *v1alpha1.PackageManifest,
 	latestVersion string,
 	repos []v1alpha1.PackageRepository) {
-	output := createOutputStructure(ctx, pkg, manifest, latestVersion, repos)
+	output := createOutputStructure(ctx, pkg, pkgs, manifest, latestVersion, repos)
 	yamlOutput, err := yaml.Marshal(output)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "❌ Could not marshal YAML output: %v\n", err)
@@ -350,6 +426,8 @@ func printYAML(ctx context.Context,
 func init() {
 	describeCmd.Flags().StringVar(&describeCmdOptions.repository, "repository", describeCmdOptions.repository,
 		"specify the name of the package repository used to use when the package is not installed")
-	RootCmd.AddCommand(describeCmd)
 	describeCmdOptions.OutputOptions.AddFlagsToCommand(describeCmd)
+	describeCmdOptions.KindOptions.AddFlagsToCommand(describeCmd)
+	describeCmdOptions.NamespaceOptions.AddFlagsToCommand(describeCmd)
+	RootCmd.AddCommand(describeCmd)
 }

--- a/cmd/glasskube/cmd/kind_options.go
+++ b/cmd/glasskube/cmd/kind_options.go
@@ -104,7 +104,7 @@ func getPackageOrClusterPackage(
 	pNotFound := !pkgTried || errp != nil
 	cpNotFound := !cpkgTried || errcp != nil
 	if pNotFound && cpNotFound {
-		return nil, fmt.Errorf("no Package or ClusterPackage found with name %v", name)
+		return nil, fmt.Errorf("no Package or ClusterPackage found with name %v: %w; %w", name, errp, errcp)
 	} else if !pNotFound && !cpNotFound {
 		return nil, fmt.Errorf("both Package and ClusterPackage found with name %v. Please specify the kind explicitly", name)
 	} else if !pNotFound && cpNotFound {

--- a/pkg/describe/describe.go
+++ b/pkg/describe/describe.go
@@ -21,7 +21,7 @@ func DescribeInstalledClusterPackage(ctx context.Context, pkgName string) (
 		return nil, nil, err
 	}
 
-	mf, err := getManifestForPkg(ctx, &pkg)
+	mf, err := GetManifestForPkg(ctx, &pkg)
 	return &pkg, mf, err
 }
 
@@ -34,11 +34,11 @@ func DescribeInstalledPackage(ctx context.Context, namespace string, name string
 		return nil, nil, err
 	}
 
-	mf, err := getManifestForPkg(ctx, &pkg)
+	mf, err := GetManifestForPkg(ctx, &pkg)
 	return &pkg, mf, err
 }
 
-func getManifestForPkg(ctx context.Context, pkg ctrlpkg.Package) (*v1alpha1.PackageManifest, error) {
+func GetManifestForPkg(ctx context.Context, pkg ctrlpkg.Package) (*v1alpha1.PackageManifest, error) {
 	if installedManifest, err := manifest.GetInstalledManifestForPackage(ctx, pkg); err == nil {
 		return installedManifest, nil
 	} else if !errors.Is(err, manifest.ErrPackageNoManifest) {


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Ref #803 <!-- Issue # here -->

## 📑 Description
The new behavior of `glasskube describe` is as follows:
- if there exists a Package or ClusterPackage with name `pkgName`, that is described (also considering all flags like `--kind` and `--namespace`
- otherwise, if there exists a package in a repository with that name, that is described
  - if that package has scope "Namespaced", additionally, a summary of all instances is shown

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->