### PR TITLE
docs(website): fix broken link

### DIFF
--- a/website/docs/03_components/02_package-operator.md
+++ b/website/docs/03_components/02_package-operator.md
@@ -7,7 +7,7 @@ The package operator follows the [Kubernetes Operator Pattern](https://kubernete
 The Package controller manages the `Package` resources of the cluster. 
 
 Whenever a `Package` has been created, changed or deleted these changes will be picked up and applied by the Package controller.
-The Package controller also makes sure that dependencies of a `Package` are met without conflicting installations, by applying the logic described [here](#dependency-management).
+The Package controller also makes sure that dependencies of a `Package` are met without conflicting installations, by applying the logic described [here](../04_design/dependency-management.md).
 
 ## PackageInfo Controller
 
@@ -69,4 +69,4 @@ while there might already be a prerelease of a new major version like `v2.0.0-al
 
 Instead of fetching `repository.xyz/package-name/package.yaml`, the operator fetches `repository.xyz/package-name/version/package.yaml`
 
-Check the [package repository docs](../package-repository#structure) and [dependency management docs](../04_design/dependency-management.md) for more information.
+Check the [package repository docs](./03_package-repository.md#structure) and [dependency management docs](../04_design/dependency-management.md) for more information.

--- a/website/guides/01_cert-manager.mdx
+++ b/website/guides/01_cert-manager.mdx
@@ -128,7 +128,7 @@ kubectl apply -f cluster-issuer.yaml
 ```
 
 Cert-manager creates an Ingress to validate the ACME challenge, if no Ingress controller is already installed in
-the cluster the [ingress-nginx controller](./ingress-nginx) can easily be installed with Glasskube.
+the cluster the [ingress-nginx controller](./02_ingress-nginx.mdx) can easily be installed with Glasskube.
 
 Further links about cert-manager:
 

--- a/website/guides/02_ingress-nginx.mdx
+++ b/website/guides/02_ingress-nginx.mdx
@@ -142,7 +142,7 @@ spec:
 
 This Ingress tells the controller that all traffic to the domain "app.your-company.com" with a path prefix of "/" should be routed to a Service in the same namespace named "your-app".
 With the addition of a `cert-manager.io/cluster-issuer` annotation and `tls` block, it also instructs [cert-manager](https://cert-manager.io/) to issue a certificate for this domain name.
-To learn more about cert-manager, check out [our guide on how to install cert-manager using Glasskube](./cert-manager).
+To learn more about cert-manager, check out [our guide on how to install cert-manager using Glasskube](./01_cert-manager.mdx).
 
 Further links about ingress-nginx:
 


### PR DESCRIPTION
Closes #881 

## 📑 Description
Fixed Broken link in website docs which caused error while building