### PR TITLE
fix(cli): remove bootstrap requirement from `auto-update` command

### DIFF
--- a/cmd/glasskube/cmd/auto-update.go
+++ b/cmd/glasskube/cmd/auto-update.go
@@ -35,7 +35,7 @@ var autoUpdateEnableCmd = &cobra.Command{
 var autoUpdateDisableCmd = &cobra.Command{
 	Use:               "disable [...package]",
 	Short:             "Disable automatic updates for packages:",
-	PreRun:            cliutils.SetupClientContext(true, &rootCmdOptions.SkipUpdateCheck),
+	PreRun:            cliutils.SetupClientContext(false, &rootCmdOptions.SkipUpdateCheck),
 	ValidArgsFunction: completeInstalledPackageNames,
 	Run: runAutoUpdateEnableOrDisable(false,
 		"Enable automatic updates for the following packages", "Automatic updates disabled"),


### PR DESCRIPTION
## 📑 Description
The command does actually require a bootstrapped cluster, but the check would require additional access rules and is not really necessary since the command would fail anyways if no package or clusterpackage crd is present in the cluster.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->