### PR TITLE
fix(ui): sticky navbar

### DIFF
--- a/internal/web/templates/layout/base.html
+++ b/internal/web/templates/layout/base.html
@@ -16,7 +16,7 @@
     sse-connect="/events"
     hx-indicator="#indicator"
     hx-target-error="#error-container">
-    <nav class="navbar navbar-expand-lg navbar-dark bg-secondary">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-secondary sticky-top">
       <div id="indicator" class="progress-container bg-transparent w-100 position-fixed top-0 start-0">
         <div class="htmx-indicator progress-bar bg-primary h-100 w-100"></div>
       </div>


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #863 

## 📑 Description
Make the navbar header stick on top even if scrolling down.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
*Old Behavior* - Even I scroll to bottom, navbar didn't stick on top.
![image](https://github.com/glasskube/glasskube/assets/58108598/5a95ca29-536a-46d8-a18b-c4f675e0b16b)


*New Behavior* - Navbar stick on top even I scrolled down.
![image](https://github.com/glasskube/glasskube/assets/58108598/86a39cc2-feb3-4b05-9b97-1cdd7c2e7886)
