### PR TITLE
feat(cli): support repo deletion with `repo delete [repoName]`

### DIFF
--- a/cmd/glasskube/cmd/repo_delete.go
+++ b/cmd/glasskube/cmd/repo_delete.go
@@ -46,10 +46,14 @@ func deleteRepository(ctx context.Context, repoName string) {
 	}
 
 	var pkgs v1alpha1.PackageList
-	_ = client.Packages("").GetAll(ctx, &pkgs)
+	if err := client.Packages("").GetAll(ctx, &pkgs); err != nil {
+		fmt.Fprintf(os.Stderr, "Could not list packages: %v", err)
+	}
 
 	var clpkgs v1alpha1.ClusterPackageList
-	_ = client.ClusterPackages().GetAll(ctx, &clpkgs)
+	if err := client.ClusterPackages().GetAll(ctx, &clpkgs); err != nil {
+		fmt.Fprintf(os.Stderr, "Could not list Cluster packages: %v", err)
+	}
 
 	repoPackages := getPackagesFromRepo(clpkgs, pkgs, repoName)
 	if len(repoPackages) > 0 {
@@ -58,7 +62,7 @@ func deleteRepository(ctx context.Context, repoName string) {
 		cliutils.ExitWithError()
 	}
 
-	if !cliutils.YesNoPrompt("Do you want to continue?", false) {
+	if !cliutils.YesNoPrompt(fmt.Sprintf("Repository %s will now be deleted. Do you want to continue?", repoName), false) {
 		fmt.Println("❌ Repository Deletion Cancelled")
 		cliutils.ExitWithError()
 	}

--- a/cmd/glasskube/cmd/repo_delete.go
+++ b/cmd/glasskube/cmd/repo_delete.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/glasskube/glasskube/api/v1alpha1"
+	"github.com/glasskube/glasskube/internal/cliutils"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var repoDeleteCmd = &cobra.Command{
+	Use:    "delete [repositoryName]",
+	Short:  "Delete a repository",
+	Args:   cobra.ExactArgs(1),
+	PreRun: cliutils.SetupClientContext(true, &rootCmdOptions.SkipUpdateCheck),
+	Run: func(cmd *cobra.Command, args []string) {
+		repositoryName := args[0]
+		ctx := cmd.Context()
+		deleteRepository(ctx, repositoryName)
+	},
+}
+
+func deleteRepository(ctx context.Context, repoName string) {
+	client := cliutils.PackageClient(ctx)
+
+	var repos v1alpha1.PackageRepositoryList
+	if err := client.PackageRepositories().GetAll(ctx, &repos); err != nil {
+		fmt.Fprintf(os.Stderr, "❌ error listing package repository: %v\n", err)
+		cliutils.ExitWithError()
+	}
+
+	var targetRepo *v1alpha1.PackageRepository
+	for i := range repos.Items {
+		if repos.Items[i].Name == repoName {
+			targetRepo = &repos.Items[i]
+			break
+		}
+	}
+
+	if targetRepo == nil {
+		fmt.Fprintf(os.Stderr, "❌ repository %s not found\n", repoName)
+		cliutils.ExitWithError()
+	}
+
+	var pkgs v1alpha1.PackageList
+	_ = client.Packages("").GetAll(ctx, &pkgs)
+
+	var clpkgs v1alpha1.ClusterPackageList
+	_ = client.ClusterPackages().GetAll(ctx, &clpkgs)
+
+	repoPackages := getPackagesFromRepo(clpkgs, pkgs, repoName)
+	if len(repoPackages) > 0 {
+		fmt.Printf("Repository %s cannot be deleted, because the following packages are installed from this repository: %v\n",
+			repoName, repoPackages)
+		cliutils.ExitWithError()
+	}
+
+	if !cliutils.YesNoPrompt("Do you want to continue?", false) {
+		fmt.Println("❌ Repository Deletion Cancelled")
+		cliutils.ExitWithError()
+	}
+	err := client.PackageRepositories().Delete(ctx, targetRepo, metav1.DeleteOptions{})
+	if err != nil {
+		fmt.Println("Error deleting repository:", err)
+		cliutils.ExitWithError()
+	}
+
+	fmt.Printf("Repository %s has been deleted.\n", repoName)
+}
+
+func getPackagesFromRepo(clpkgs v1alpha1.ClusterPackageList, pkgs v1alpha1.PackageList, repoName string) []string {
+	var repoPackages []string
+	for _, clpkg := range clpkgs.Items {
+		if clpkg.Spec.PackageInfo.RepositoryName == repoName {
+			repoPackages = append(repoPackages, clpkg.Name)
+		}
+	}
+
+	for _, pkg := range pkgs.Items {
+		if pkg.Spec.PackageInfo.RepositoryName == repoName {
+			repoPackages = append(repoPackages, pkg.Name)
+		}
+	}
+	return repoPackages
+}
+
+func init() {
+	repoCmd.AddCommand(repoDeleteCmd)
+}


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #681 

## 📑 Description
PackageRepositories now can be deleted using `repo delete [repoName]`


```
$ glasskube repo delete default                                                                                          
Repository default will now be deleted. Do you want to continue? y
Repository default has been deleted.

```

```
$ glasskube repo delete glasskube                                                                                        
Repository default will now be deleted. Do you want to continue? n
❌ Repository Deletion Cancelled
exit status 1
```

When a package is installed from the PackageRepository,
```
$ glasskube install cyclops                                                                                        
Version not specified. The latest version v0.7.1+1 of cyclops will be installed.
Would you like to enable automatic updates? (y/N) y
Summary:
 * The following packages will be installed in your cluster (minikube):
    1. cyclops (version v0.7.1+1)
 * Automatic updates will be enabled
Continue? (Y/n) y
✅ cyclops is now installed in minikube.

$ glasskube repo delete default                                                                              
Repository default cannot be deleted, because the following packages are installed from this repository: cyclops, sealed-secrets
exit status 1
```

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->