### PR TITLE
fix(ui): show an error if the client cache is out of sync

### DIFF
--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -247,3 +247,9 @@ func SetUserProperty(key string, value string) {
 		},
 	})
 }
+
+func ReportCacheVerificationError(err error) {
+	ev := instance.getBaseEvent("error_cache_verification", false)
+	ev.Properties["err"] = err.Error()
+	_ = instance.posthog.Enqueue(ev)
+}

--- a/internal/web/cacheverifier.go
+++ b/internal/web/cacheverifier.go
@@ -1,0 +1,214 @@
+package web
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/glasskube/glasskube/api/v1alpha1"
+	"github.com/glasskube/glasskube/pkg/client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+)
+
+type cacheVerifier struct {
+	lister     verifyLister
+	diffMap    sync.Map
+	restConfig *rest.Config
+	stopCh     chan struct{}
+	errCh      chan error
+}
+
+type diffMapEntry struct {
+	cachedResourceVersion    string
+	nonCachedResourceVersion string
+}
+
+type cacheVerificationError struct {
+	itemName                 string
+	cachedResourceVersion    string
+	nonCachedResourceVersion string
+}
+
+func (e *cacheVerificationError) Error() string {
+	return fmt.Sprintf("cache verification for %s failed two times in a row "+
+		"(cached resource version is '%s', but expected '%s')", e.itemName, e.cachedResourceVersion, e.nonCachedResourceVersion)
+}
+
+func newVerifier(restConfig *rest.Config, lister verifyLister) *cacheVerifier {
+	return &cacheVerifier{
+		restConfig: restConfig,
+		stopCh:     make(chan struct{}),
+		errCh:      make(chan error, 1),
+		lister:     lister,
+	}
+}
+
+func (verifier *cacheVerifier) listItems(ctx context.Context, client client.PackageV1Alpha1Client) ([]metav1.Object, error) {
+	return verifier.lister(ctx, client)
+}
+
+type verifyLister = func(ctx context.Context, client client.PackageV1Alpha1Client) ([]metav1.Object, error)
+
+var clusterPackageVerifyLister = func(ctx context.Context, client client.PackageV1Alpha1Client) ([]metav1.Object, error) {
+	var ls v1alpha1.ClusterPackageList
+	err := client.ClusterPackages().GetAll(ctx, &ls)
+	target := make([]metav1.Object, len(ls.Items))
+	for idx, item := range ls.Items {
+		target[idx] = item.GetObjectMeta()
+	}
+	return target, err
+}
+
+var packageVerifyLister = func(ctx context.Context, client client.PackageV1Alpha1Client) ([]metav1.Object, error) {
+	var ls v1alpha1.PackageList
+	err := client.Packages("").GetAll(ctx, &ls)
+	target := make([]metav1.Object, len(ls.Items))
+	for idx, item := range ls.Items {
+		target[idx] = item.GetObjectMeta()
+	}
+	return target, err
+}
+
+var packageInfoVerifyLister = func(ctx context.Context, client client.PackageV1Alpha1Client) ([]metav1.Object, error) {
+	var ls v1alpha1.PackageInfoList
+	err := client.PackageInfos().GetAll(ctx, &ls)
+	target := make([]metav1.Object, len(ls.Items))
+	for idx, item := range ls.Items {
+		target[idx] = item.GetObjectMeta()
+	}
+	return target, err
+}
+
+var packageRepoVerifyLister = func(ctx context.Context, client client.PackageV1Alpha1Client) ([]metav1.Object, error) {
+	var ls v1alpha1.PackageRepositoryList
+	err := client.PackageRepositories().GetAll(ctx, &ls)
+	target := make([]metav1.Object, len(ls.Items))
+	for idx, item := range ls.Items {
+		target[idx] = item.GetObjectMeta()
+	}
+	return target, err
+}
+
+func (verifier *cacheVerifier) start(ctx context.Context, cachedClient client.PackageV1Alpha1Client, minInterval float32) {
+	// setup client without cache
+	nonCachedClient := client.NewOrDie(verifier.restConfig)
+
+	var diffErr *cacheVerificationError
+
+endlessLoop:
+	for {
+		time.Sleep(time.Second * time.Duration(minInterval*(rand.Float32()+1))) // between [minInterval, 2*minInterval) seconds
+
+		if nonCachedItems, err := verifier.listItems(ctx, nonCachedClient); err != nil {
+			fmt.Fprintf(os.Stderr, "CACHEVERIFIER: failed to get actual items: %v\n", err)
+		} else if cachedItems, err := verifier.listItems(ctx, cachedClient); err != nil {
+			fmt.Fprintf(os.Stderr, "CACHEVERIFIER: failed get cached items: %v\n", err)
+		} else {
+		outerLoop:
+			for _, nonCachedItem := range nonCachedItems {
+				for _, cachedItem := range cachedItems {
+					if nonCachedItem.GetNamespace() == cachedItem.GetNamespace() &&
+						nonCachedItem.GetName() == cachedItem.GetName() {
+						if nonCachedItem.GetResourceVersion() != cachedItem.GetResourceVersion() {
+							fmt.Fprintf(os.Stderr, "CACHEVERIFIER: resource versions of %s differ, need to check\n",
+								cachedItem.GetName())
+							if err := verifier.handleDiff(cachedItem, nonCachedItem); errors.As(err, &diffErr) {
+								break endlessLoop
+							} else if err != nil {
+								fmt.Fprintf(os.Stderr, "CACHEVERIFIER: failed to handle diffs: %v\n", err)
+							}
+						} else {
+							// previously stored inconsistency of this item can now be deleted
+							verifier.diffMap.Delete(cache.MetaObjectToName(cachedItem).String())
+						}
+						continue outerLoop
+					}
+				}
+				fmt.Fprintf(os.Stderr, "CACHEVERIFIER: non-cached item %s not found in cache, need to check\n",
+					nonCachedItem.GetName())
+				// non cached package found, that is not in cache (yet?)
+				if err := verifier.handleDiff(nil, nonCachedItem); errors.As(err, &diffErr) {
+					break endlessLoop
+				} else if err != nil {
+					fmt.Fprintf(os.Stderr, "CACHEVERIFIER: failed to handle diffs: %v\n", err)
+				}
+			}
+
+			// check the other way around (i.e. whether there are cached items, that are not in the non-cached list anymore)
+			for _, cachedClPkg := range cachedItems {
+				found := false
+				for _, nonCachedClPkg := range nonCachedItems {
+					if nonCachedClPkg.GetNamespace() == cachedClPkg.GetNamespace() &&
+						nonCachedClPkg.GetName() == cachedClPkg.GetName() {
+						found = true
+						break
+					}
+				}
+				if !found {
+					fmt.Fprintf(os.Stderr, "CACHEVERIFIER: cached item %s not found in non-cached list, need to check\n",
+						cachedClPkg.GetName())
+					// when here, there exists a cached item, that is not in the non-cached list
+					if err := verifier.handleDiff(cachedClPkg, nil); errors.As(err, &diffErr) {
+						break endlessLoop
+					} else if err != nil {
+						fmt.Fprintf(os.Stderr, "CACHEVERIFIER: failed to handle diffs: %v\n", err)
+					}
+				}
+			}
+		}
+	}
+	verifier.closeAndReset(diffErr)
+}
+
+func (verifier *cacheVerifier) closeAndReset(err error) {
+	close(verifier.stopCh)
+	verifier.diffMap = sync.Map{}
+	verifier.stopCh = make(chan struct{})
+	verifier.errCh <- err
+}
+
+func (verifier *cacheVerifier) handleDiff(cachedObj metav1.Object, nonCachedObj metav1.Object) error {
+	var diffMapKey string
+	var cachedResourceVersion string
+	var nonCachedResourceVersion string
+	if cachedObj != nil {
+		diffMapKey = cache.MetaObjectToName(cachedObj).String()
+		cachedResourceVersion = cachedObj.GetResourceVersion()
+	}
+	if nonCachedObj != nil {
+		diffMapKey = cache.MetaObjectToName(nonCachedObj).String()
+		nonCachedResourceVersion = nonCachedObj.GetResourceVersion()
+	}
+
+	updatedEntry := diffMapEntry{
+		cachedResourceVersion:    cachedResourceVersion,
+		nonCachedResourceVersion: nonCachedResourceVersion,
+	}
+
+	if entry, exists := verifier.diffMap.LoadOrStore(diffMapKey, updatedEntry); exists {
+		if lastDiff, ok := entry.(diffMapEntry); ok {
+			if lastDiff.cachedResourceVersion == cachedResourceVersion {
+				// if cached item has not been updated since last time, we are probably stuck
+				return &cacheVerificationError{
+					itemName:                 diffMapKey,
+					cachedResourceVersion:    cachedResourceVersion,
+					nonCachedResourceVersion: nonCachedResourceVersion,
+				}
+			} else {
+				// cached item has been updated since last time, but is not yet update, which is okay
+				// we consider this as not being stuck (yet), but mark for check in next round
+				verifier.diffMap.Store(diffMapKey, updatedEntry)
+			}
+		} else {
+			return errors.New("unexpected cache type in diffMap")
+		}
+	}
+
+	return nil
+}

--- a/internal/web/constants.go
+++ b/internal/web/constants.go
@@ -1,0 +1,4 @@
+package web
+
+const refreshPkgOverview = "refresh-package-overview"
+const refreshClusterPkgOverview = "refresh-clusterpackage-overview"

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -17,6 +17,9 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
+
+	clientadapter "github.com/glasskube/glasskube/internal/adapter/goclient"
 
 	"github.com/glasskube/glasskube/internal/controller/ctrlpkg"
 
@@ -24,7 +27,6 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/glasskube/glasskube/api/v1alpha1"
-	clientadapter "github.com/glasskube/glasskube/internal/adapter/goclient"
 	"github.com/glasskube/glasskube/internal/clientutils"
 	"github.com/glasskube/glasskube/internal/cliutils"
 	"github.com/glasskube/glasskube/internal/config"
@@ -99,6 +101,7 @@ type server struct {
 	restConfig         *rest.Config
 	rawConfig          *api.Config
 	pkgClient          client.PackageV1Alpha1Client
+	nonCachedClient    client.PackageV1Alpha1Client
 	repoClientset      repoclient.RepoClientset
 	k8sClient          *kubernetes.Clientset
 	sseHub             *SSEHub
@@ -1055,13 +1058,27 @@ func (server *server) initKubeConfig() ServerConfigError {
 
 	server.restConfig = restConfig
 	server.rawConfig = rawConfig
-	server.pkgClient = client // be aware that server.pkgClient is overridden with the cached client once bootstrap check succeeded
+	server.nonCachedClient = client // this should never be overridden
+	server.pkgClient = client       // be aware that server.pkgClient is overridden with the cached client once bootstrap check succeeded
 	return nil
 }
 
 func (server *server) initWhenBootstrapped(ctx context.Context) {
 	server.k8sClient = kubernetes.NewForConfigOrDie(server.restConfig)
 	server.initCachedClient(context.WithoutCancel(ctx))
+	server.initClientDependentComponents()
+	factory := informers.NewSharedInformerFactory(server.k8sClient, 0)
+	c := make(chan struct{})
+	namespaceLister := factory.Core().V1().Namespaces().Lister()
+	server.namespaceLister = &namespaceLister
+	configMapLister := factory.Core().V1().ConfigMaps().Lister()
+	server.configMapLister = &configMapLister
+	secretLister := factory.Core().V1().Secrets().Lister()
+	server.secretLister = &secretLister
+	factory.Start(c)
+}
+
+func (server *server) initClientDependentComponents() {
 	server.repoClientset = repoclient.NewClientset(
 		clientadapter.NewPackageClientAdapter(server.pkgClient),
 		clientadapter.NewKubernetesClientAdapter(server.k8sClient),
@@ -1075,15 +1092,6 @@ func (server *server) initWhenBootstrapped(ctx context.Context) {
 		clientadapter.NewPackageClientAdapter(server.pkgClient),
 		clientadapter.NewKubernetesClientAdapter(server.k8sClient),
 	)
-	factory := informers.NewSharedInformerFactory(server.k8sClient, 0)
-	c := make(chan struct{})
-	namespaceLister := factory.Core().V1().Namespaces().Lister()
-	server.namespaceLister = &namespaceLister
-	configMapLister := factory.Core().V1().ConfigMaps().Lister()
-	server.configMapLister = &configMapLister
-	secretLister := factory.Core().V1().Secrets().Lister()
-	server.secretLister = &secretLister
-	factory.Start(c)
 }
 
 func (server *server) initCachedClient(ctx context.Context) {
@@ -1091,11 +1099,73 @@ func (server *server) initCachedClient(ctx context.Context) {
 	packageStore, packageController := server.initPackageStoreAndController(ctx)
 	packageInfoStore, packageInfoController := server.initPackageInfoStoreAndController(ctx)
 	packageRepoStore, packageRepoController := server.initPackageRepoStoreAndController(ctx)
+	server.pkgClient = server.nonCachedClient.WithStores(clusterPackageStore, packageStore, packageInfoStore, packageRepoStore)
+
+	clpkgVerifier := newVerifier(server.restConfig, clusterPackageVerifyLister)
+	pkgVerifier := newVerifier(server.restConfig, packageVerifyLister)
+	pkgInfoVerifier := newVerifier(server.restConfig, packageInfoVerifyLister)
+	pkgRepoVerifier := newVerifier(server.restConfig, packageRepoVerifyLister)
+
 	go clusterPackageController.Run(ctx.Done())
 	go packageController.Run(ctx.Done())
 	go packageInfoController.Run(ctx.Done())
 	go packageRepoController.Run(ctx.Done())
-	server.pkgClient = server.pkgClient.WithStores(clusterPackageStore, packageStore, packageInfoStore, packageRepoStore)
+
+	go server.broadcastUpdatesWhenInitiallySynced(clusterPackageController, packageController, packageInfoController, packageRepoController)
+
+	go func() {
+		for {
+			select {
+			case err := <-clpkgVerifier.errCh:
+				server.handleVerificationError(err)
+			case err := <-pkgVerifier.errCh:
+				server.handleVerificationError(err)
+			case err := <-pkgInfoVerifier.errCh:
+				server.handleVerificationError(err)
+			case err := <-pkgRepoVerifier.errCh:
+				server.handleVerificationError(err)
+			}
+			cliutils.ExitWithError()
+		}
+	}()
+
+	go clpkgVerifier.start(ctx, server.pkgClient, 5)
+	go pkgVerifier.start(ctx, server.pkgClient, 10)
+	go pkgInfoVerifier.start(ctx, server.pkgClient, 10)
+	go pkgRepoVerifier.start(ctx, server.pkgClient, 30)
+}
+
+func (s *server) broadcastUpdatesWhenInitiallySynced(controllers ...cache.Controller) {
+	tick := time.NewTicker(500 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		if s.allControllersInitiallySynced(controllers...) {
+			s.sseHub.Broadcast <- &sse{
+				event: refreshClusterPkgOverview,
+			}
+			// TODO all possible refreshes
+			break
+		}
+		<-tick.C
+	}
+}
+
+func (s *server) allControllersInitiallySynced(controllers ...cache.Controller) bool {
+	for _, c := range controllers {
+		if !c.HasSynced() {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *server) handleVerificationError(err error) {
+	fmt.Fprintf(os.Stderr, "\n\n\n\nOUT OF SYNC – Local cache is probably outdated: %v\n", err)
+	fmt.Fprintf(os.Stderr, "This is a known issue, see https://github.com/glasskube/glasskube/issues/838 – "+
+		"As a consequence, the UI will appear stuck.\n")
+	fmt.Fprintf(os.Stderr, "The server will stop now, please restart it manually and reload the UI in the browser! "+
+		"(Of course we will fix this, sorry.)\n\n\n\n\n")
+	telemetry.ReportCacheVerificationError(err)
 }
 
 func (s *server) enrichContext(h http.Handler) http.Handler {
@@ -1148,7 +1218,7 @@ func defaultKubeconfigExists() bool {
 }
 
 func (s *server) initClusterPackageStoreAndController(ctx context.Context) (cache.Store, cache.Controller) {
-	pkgClient := s.pkgClient
+	pkgClient := s.nonCachedClient
 	return cache.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -1157,7 +1227,7 @@ func (s *server) initClusterPackageStoreAndController(ctx context.Context) (cach
 				return &pkgList, err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				return pkgClient.ClusterPackages().Watch(ctx, withDecreasedTimeout(options))
+				return pkgClient.ClusterPackages().Watch(ctx, options)
 			},
 		},
 		&v1alpha1.ClusterPackage{},
@@ -1188,7 +1258,7 @@ func (s *server) initClusterPackageStoreAndController(ctx context.Context) (cach
 }
 
 func (s *server) initPackageStoreAndController(ctx context.Context) (cache.Store, cache.Controller) {
-	pkgClient := s.pkgClient
+	pkgClient := s.nonCachedClient
 	return cache.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -1197,7 +1267,7 @@ func (s *server) initPackageStoreAndController(ctx context.Context) (cache.Store
 				return &pkgList, err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				return pkgClient.Packages("").Watch(ctx, withDecreasedTimeout(options))
+				return pkgClient.Packages("").Watch(ctx, options)
 			},
 		},
 		&v1alpha1.Package{},
@@ -1229,7 +1299,7 @@ func (s *server) initPackageStoreAndController(ctx context.Context) (cache.Store
 
 func (s *server) broadcastClusterPackageRefreshTriggers(pkg *v1alpha1.ClusterPackage) {
 	s.sseHub.Broadcast <- &sse{
-		event: "refresh-clusterpackage-overview",
+		event: refreshClusterPkgOverview,
 	}
 	s.sseHub.Broadcast <- &sse{
 		event: fmt.Sprintf("refresh-pkg-detail-%s", pkg.Name),
@@ -1238,7 +1308,7 @@ func (s *server) broadcastClusterPackageRefreshTriggers(pkg *v1alpha1.ClusterPac
 
 func (s *server) broadcastPackageRefreshTriggers(pkg *v1alpha1.Package) {
 	s.sseHub.Broadcast <- &sse{
-		event: "refresh-package-overview",
+		event: refreshPkgOverview,
 	}
 	s.sseHub.Broadcast <- &sse{
 		event: fmt.Sprintf("refresh-pkg-detail-%s-%s", pkg.Namespace, pkg.Name),
@@ -1246,7 +1316,7 @@ func (s *server) broadcastPackageRefreshTriggers(pkg *v1alpha1.Package) {
 }
 
 func (s *server) initPackageInfoStoreAndController(ctx context.Context) (cache.Store, cache.Controller) {
-	pkgClient := s.pkgClient
+	pkgClient := s.nonCachedClient
 	return cache.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -1255,7 +1325,7 @@ func (s *server) initPackageInfoStoreAndController(ctx context.Context) (cache.S
 				return &packageInfoList, err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				return pkgClient.PackageInfos().Watch(ctx, withDecreasedTimeout(options))
+				return pkgClient.PackageInfos().Watch(ctx, options)
 			},
 		},
 		&v1alpha1.PackageInfo{},
@@ -1265,7 +1335,7 @@ func (s *server) initPackageInfoStoreAndController(ctx context.Context) (cache.S
 }
 
 func (s *server) initPackageRepoStoreAndController(ctx context.Context) (cache.Store, cache.Controller) {
-	pkgClient := s.pkgClient
+	pkgClient := s.nonCachedClient
 	return cache.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -1274,22 +1344,13 @@ func (s *server) initPackageRepoStoreAndController(ctx context.Context) (cache.S
 				return &repositoryList, err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				return pkgClient.PackageRepositories().Watch(ctx, withDecreasedTimeout(options))
+				return pkgClient.PackageRepositories().Watch(ctx, options)
 			},
 		},
 		&v1alpha1.PackageRepository{},
 		0,
 		cache.ResourceEventHandlerFuncs{}, // TODO we might also want to update here?
 	)
-}
-
-func withDecreasedTimeout(opts metav1.ListOptions) metav1.ListOptions {
-	if opts.TimeoutSeconds != nil {
-		// reuse the randomized timeout and divide by 10
-		t := *opts.TimeoutSeconds / 10
-		opts.TimeoutSeconds = &t
-	}
-	return opts
 }
 
 func (s *server) isUpdateAvailableForPkg(ctx context.Context, pkg ctrlpkg.Package) bool {


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Ref #838
Closes #768 
Undoes changes of #843

## 📑 Description
As the reconnection logic of #875 does not work yet, we want to provide users with a log message in the server, and shut it down so that it's necessary to restart manually again. This is of course far from ideal, but the best/cheapest way to tell the user something is wrong (the UI will show the "disconnected" banner when the server is down). 

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->