### PR TITLE
feat(cli): display status message in `glasskube list`

### DIFF
--- a/cmd/glasskube/cmd/list.go
+++ b/cmd/glasskube/cmd/list.go
@@ -129,7 +129,7 @@ func handleEmptyList(resource string) {
 }
 
 func printClusterPackageTable(packages []*list.PackageWithStatus) {
-	header := []string{"NAME", "STATUS", "VERSION", "AUTO-UPDATE", "MESSAGE"}
+	header := []string{"NAME", "STATUS", "VERSION", "AUTO-UPDATE"}
 	if listCmdOptions.ShowLatestVersion {
 		header = append(header, "LATEST VERSION")
 	}
@@ -137,13 +137,14 @@ func printClusterPackageTable(packages []*list.PackageWithStatus) {
 	if listCmdOptions.ShowDescription {
 		header = append(header, "DESCRIPTION")
 	}
+	header = append(header, "MESSAGE")
 
 	err := cliutils.PrintTable(os.Stdout,
 		packages,
 		header,
 		func(pkg *list.PackageWithStatus) []string {
 			row := []string{pkg.Name, statusString(*pkg), versionString(*pkg),
-				clientutils.AutoUpdateString(pkg.ClusterPackage, ""), messageString(*pkg)}
+				clientutils.AutoUpdateString(pkg.ClusterPackage, "")}
 			if listCmdOptions.ShowLatestVersion {
 				row = append(row, pkg.LatestVersion)
 			}
@@ -163,6 +164,7 @@ func printClusterPackageTable(packages []*list.PackageWithStatus) {
 			if listCmdOptions.ShowDescription {
 				row = append(row, pkg.ShortDescription)
 			}
+			row = append(row, messageString(*pkg))
 			return row
 		})
 	if err != nil {
@@ -172,7 +174,7 @@ func printClusterPackageTable(packages []*list.PackageWithStatus) {
 }
 
 func printPackageTable(packages []*list.PackagesWithStatus) {
-	header := []string{"PACKAGENAME", "NAMESPACE", "NAME", "STATUS", "VERSION", "AUTO-UPDATE", "MESSAGE"}
+	header := []string{"PACKAGENAME", "NAMESPACE", "NAME", "STATUS", "VERSION", "AUTO-UPDATE"}
 	if listCmdOptions.ShowLatestVersion {
 		header = append(header, "LATEST VERSION")
 	}
@@ -180,6 +182,7 @@ func printPackageTable(packages []*list.PackagesWithStatus) {
 	if listCmdOptions.ShowDescription {
 		header = append(header, "DESCRIPTION")
 	}
+	header = append(header, "MESSAGE")
 
 	var flattenedPkgs []*list.PackageWithStatus
 	for _, pkgs := range packages {
@@ -197,7 +200,7 @@ func printPackageTable(packages []*list.PackagesWithStatus) {
 		header,
 		func(pkg *list.PackageWithStatus) []string {
 			row := []string{pkg.Name, pkgNamespaceString(*pkg), pkgNameString(*pkg), statusString(*pkg), versionString(*pkg),
-				clientutils.AutoUpdateString(pkg.Package, ""), messageString(*pkg)}
+				clientutils.AutoUpdateString(pkg.Package, "")}
 			if listCmdOptions.ShowLatestVersion {
 				row = append(row, pkg.LatestVersion)
 			}
@@ -217,6 +220,7 @@ func printPackageTable(packages []*list.PackagesWithStatus) {
 			if listCmdOptions.ShowDescription {
 				row = append(row, pkg.ShortDescription)
 			}
+			row = append(row, messageString(*pkg))
 			return row
 		})
 	if err != nil {

--- a/cmd/glasskube/cmd/list.go
+++ b/cmd/glasskube/cmd/list.go
@@ -137,6 +137,7 @@ func printClusterPackageTable(packages []*list.PackageWithStatus) {
 	if listCmdOptions.ShowDescription {
 		header = append(header, "DESCRIPTION")
 	}
+
 	header = append(header, "STATUS")
 	header = append(header, "MESSAGE")
 

--- a/cmd/glasskube/cmd/list.go
+++ b/cmd/glasskube/cmd/list.go
@@ -129,7 +129,7 @@ func handleEmptyList(resource string) {
 }
 
 func printClusterPackageTable(packages []*list.PackageWithStatus) {
-	header := []string{"NAME", "STATUS", "MESSAGE", "VERSION", "AUTO-UPDATE"}
+	header := []string{"NAME", "STATUS", "VERSION", "AUTO-UPDATE", "MESSAGE"}
 	if listCmdOptions.ShowLatestVersion {
 		header = append(header, "LATEST VERSION")
 	}
@@ -142,8 +142,8 @@ func printClusterPackageTable(packages []*list.PackageWithStatus) {
 		packages,
 		header,
 		func(pkg *list.PackageWithStatus) []string {
-			row := []string{pkg.Name, statusString(*pkg), messageString(*pkg), versionString(*pkg),
-				clientutils.AutoUpdateString(pkg.ClusterPackage, "")}
+			row := []string{pkg.Name, statusString(*pkg), versionString(*pkg),
+				clientutils.AutoUpdateString(pkg.ClusterPackage, ""), messageString(*pkg)}
 			if listCmdOptions.ShowLatestVersion {
 				row = append(row, pkg.LatestVersion)
 			}
@@ -172,7 +172,7 @@ func printClusterPackageTable(packages []*list.PackageWithStatus) {
 }
 
 func printPackageTable(packages []*list.PackagesWithStatus) {
-	header := []string{"PACKAGENAME", "NAMESPACE", "NAME", "STATUS", "MESSAGE", "VERSION", "AUTO-UPDATE"}
+	header := []string{"PACKAGENAME", "NAMESPACE", "NAME", "STATUS", "VERSION", "AUTO-UPDATE", "MESSAGE"}
 	if listCmdOptions.ShowLatestVersion {
 		header = append(header, "LATEST VERSION")
 	}
@@ -196,8 +196,8 @@ func printPackageTable(packages []*list.PackagesWithStatus) {
 		flattenedPkgs,
 		header,
 		func(pkg *list.PackageWithStatus) []string {
-			row := []string{pkg.Name, pkgNamespaceString(*pkg), pkgNameString(*pkg), statusString(*pkg), messageString(*pkg), versionString(*pkg),
-				clientutils.AutoUpdateString(pkg.Package, "")}
+			row := []string{pkg.Name, pkgNamespaceString(*pkg), pkgNameString(*pkg), statusString(*pkg), versionString(*pkg),
+				clientutils.AutoUpdateString(pkg.Package, ""), messageString(*pkg)}
 			if listCmdOptions.ShowLatestVersion {
 				row = append(row, pkg.LatestVersion)
 			}
@@ -277,7 +277,7 @@ func statusString(pkg list.PackageWithStatus) string {
 
 func messageString(pkg list.PackageWithStatus) string {
 	if pkg.Status != nil {
-		return pkg.Status.Reason
+		return pkg.Status.Message
 	} else {
 		return ""
 	}

--- a/cmd/glasskube/cmd/list.go
+++ b/cmd/glasskube/cmd/list.go
@@ -129,7 +129,7 @@ func handleEmptyList(resource string) {
 }
 
 func printClusterPackageTable(packages []*list.PackageWithStatus) {
-	header := []string{"NAME", "STATUS", "VERSION", "AUTO-UPDATE"}
+	header := []string{"NAME", "VERSION", "AUTO-UPDATE"}
 	if listCmdOptions.ShowLatestVersion {
 		header = append(header, "LATEST VERSION")
 	}
@@ -137,13 +137,14 @@ func printClusterPackageTable(packages []*list.PackageWithStatus) {
 	if listCmdOptions.ShowDescription {
 		header = append(header, "DESCRIPTION")
 	}
+	header = append(header, "STATUS")
 	header = append(header, "MESSAGE")
 
 	err := cliutils.PrintTable(os.Stdout,
 		packages,
 		header,
 		func(pkg *list.PackageWithStatus) []string {
-			row := []string{pkg.Name, statusString(*pkg), versionString(*pkg),
+			row := []string{pkg.Name, versionString(*pkg),
 				clientutils.AutoUpdateString(pkg.ClusterPackage, "")}
 			if listCmdOptions.ShowLatestVersion {
 				row = append(row, pkg.LatestVersion)
@@ -164,6 +165,7 @@ func printClusterPackageTable(packages []*list.PackageWithStatus) {
 			if listCmdOptions.ShowDescription {
 				row = append(row, pkg.ShortDescription)
 			}
+			row = append(row, statusString(*pkg))
 			row = append(row, messageString(*pkg))
 			return row
 		})
@@ -174,7 +176,7 @@ func printClusterPackageTable(packages []*list.PackageWithStatus) {
 }
 
 func printPackageTable(packages []*list.PackagesWithStatus) {
-	header := []string{"PACKAGENAME", "NAMESPACE", "NAME", "STATUS", "VERSION", "AUTO-UPDATE"}
+	header := []string{"PACKAGENAME", "NAMESPACE", "NAME", "VERSION", "AUTO-UPDATE"}
 	if listCmdOptions.ShowLatestVersion {
 		header = append(header, "LATEST VERSION")
 	}
@@ -182,6 +184,7 @@ func printPackageTable(packages []*list.PackagesWithStatus) {
 	if listCmdOptions.ShowDescription {
 		header = append(header, "DESCRIPTION")
 	}
+	header = append(header, "STATUS")
 	header = append(header, "MESSAGE")
 
 	var flattenedPkgs []*list.PackageWithStatus
@@ -199,7 +202,7 @@ func printPackageTable(packages []*list.PackagesWithStatus) {
 		flattenedPkgs,
 		header,
 		func(pkg *list.PackageWithStatus) []string {
-			row := []string{pkg.Name, pkgNamespaceString(*pkg), pkgNameString(*pkg), statusString(*pkg), versionString(*pkg),
+			row := []string{pkg.Name, pkgNamespaceString(*pkg), pkgNameString(*pkg), versionString(*pkg),
 				clientutils.AutoUpdateString(pkg.Package, "")}
 			if listCmdOptions.ShowLatestVersion {
 				row = append(row, pkg.LatestVersion)
@@ -220,6 +223,7 @@ func printPackageTable(packages []*list.PackagesWithStatus) {
 			if listCmdOptions.ShowDescription {
 				row = append(row, pkg.ShortDescription)
 			}
+			row = append(row, statusString(*pkg))
 			row = append(row, messageString(*pkg))
 			return row
 		})

--- a/cmd/glasskube/cmd/list.go
+++ b/cmd/glasskube/cmd/list.go
@@ -21,6 +21,7 @@ type ListCmdOptions struct {
 	ListOutdatedOnly  bool
 	ShowDescription   bool
 	ShowLatestVersion bool
+	ShowMessage       bool
 	More              bool
 	OutputOptions
 	KindOptions
@@ -49,6 +50,7 @@ var listCmd = &cobra.Command{
 		if listCmdOptions.More {
 			listCmdOptions.ShowLatestVersion = true
 			listCmdOptions.ShowDescription = true
+			listCmdOptions.ShowMessage = true
 		}
 		lister := list.NewListerWithRepoCache(ctx)
 		var clPkgs []*list.PackageWithStatus
@@ -95,6 +97,8 @@ func init() {
 		"show the (cluster-)package description")
 	listCmd.PersistentFlags().BoolVar(&listCmdOptions.ShowLatestVersion, "show-latest", false,
 		"show the latest version of (cluster-)packages if available")
+	listCmd.PersistentFlags().BoolVar(&listCmdOptions.ShowMessage, "show-message", false,
+		"show the messages of (cluster-)packages")
 	listCmd.PersistentFlags().BoolVarP(&listCmdOptions.More, "more", "m", false,
 		"show additional information about (cluster-)packages (like --show-description --show-latest)")
 	listCmdOptions.OutputOptions.AddFlagsToCommand(listCmd)
@@ -137,9 +141,10 @@ func printClusterPackageTable(packages []*list.PackageWithStatus) {
 	if listCmdOptions.ShowDescription {
 		header = append(header, "DESCRIPTION")
 	}
-
 	header = append(header, "STATUS")
-	header = append(header, "MESSAGE")
+	if listCmdOptions.ShowMessage {
+		header = append(header, "Message")
+	}
 
 	err := cliutils.PrintTable(os.Stdout,
 		packages,
@@ -167,7 +172,9 @@ func printClusterPackageTable(packages []*list.PackageWithStatus) {
 				row = append(row, pkg.ShortDescription)
 			}
 			row = append(row, statusString(*pkg))
-			row = append(row, messageString(*pkg))
+			if listCmdOptions.ShowMessage {
+				row = append(row, messageString(*pkg))
+			}
 			return row
 		})
 	if err != nil {
@@ -186,7 +193,9 @@ func printPackageTable(packages []*list.PackagesWithStatus) {
 		header = append(header, "DESCRIPTION")
 	}
 	header = append(header, "STATUS")
-	header = append(header, "MESSAGE")
+	if listCmdOptions.ShowMessage {
+		header = append(header, "MESSAGE")
+	}
 
 	var flattenedPkgs []*list.PackageWithStatus
 	for _, pkgs := range packages {
@@ -225,7 +234,9 @@ func printPackageTable(packages []*list.PackagesWithStatus) {
 				row = append(row, pkg.ShortDescription)
 			}
 			row = append(row, statusString(*pkg))
-			row = append(row, messageString(*pkg))
+			if listCmdOptions.ShowMessage {
+				row = append(row, messageString(*pkg))
+			}
 			return row
 		})
 	if err != nil {

--- a/cmd/glasskube/cmd/list.go
+++ b/cmd/glasskube/cmd/list.go
@@ -106,6 +106,7 @@ func init() {
 
 	listCmd.MarkFlagsMutuallyExclusive("show-description", "more")
 	listCmd.MarkFlagsMutuallyExclusive("show-latest", "more")
+	listCmd.MarkFlagsMutuallyExclusive("show-message", "more")
 
 	RootCmd.AddCommand(listCmd)
 }

--- a/cmd/glasskube/cmd/list.go
+++ b/cmd/glasskube/cmd/list.go
@@ -129,7 +129,7 @@ func handleEmptyList(resource string) {
 }
 
 func printClusterPackageTable(packages []*list.PackageWithStatus) {
-	header := []string{"NAME", "STATUS", "VERSION", "AUTO-UPDATE"}
+	header := []string{"NAME", "STATUS", "MESSAGE", "VERSION", "AUTO-UPDATE"}
 	if listCmdOptions.ShowLatestVersion {
 		header = append(header, "LATEST VERSION")
 	}
@@ -142,7 +142,7 @@ func printClusterPackageTable(packages []*list.PackageWithStatus) {
 		packages,
 		header,
 		func(pkg *list.PackageWithStatus) []string {
-			row := []string{pkg.Name, statusString(*pkg), versionString(*pkg),
+			row := []string{pkg.Name, statusString(*pkg), messageString(*pkg), versionString(*pkg),
 				clientutils.AutoUpdateString(pkg.ClusterPackage, "")}
 			if listCmdOptions.ShowLatestVersion {
 				row = append(row, pkg.LatestVersion)
@@ -172,7 +172,7 @@ func printClusterPackageTable(packages []*list.PackageWithStatus) {
 }
 
 func printPackageTable(packages []*list.PackagesWithStatus) {
-	header := []string{"PACKAGENAME", "NAMESPACE", "NAME", "STATUS", "VERSION", "AUTO-UPDATE"}
+	header := []string{"PACKAGENAME", "NAMESPACE", "NAME", "STATUS", "MESSAGE", "VERSION", "AUTO-UPDATE"}
 	if listCmdOptions.ShowLatestVersion {
 		header = append(header, "LATEST VERSION")
 	}
@@ -196,7 +196,7 @@ func printPackageTable(packages []*list.PackagesWithStatus) {
 		flattenedPkgs,
 		header,
 		func(pkg *list.PackageWithStatus) []string {
-			row := []string{pkg.Name, pkgNamespaceString(*pkg), pkgNameString(*pkg), statusString(*pkg), versionString(*pkg),
+			row := []string{pkg.Name, pkgNamespaceString(*pkg), pkgNameString(*pkg), statusString(*pkg), messageString(*pkg), versionString(*pkg),
 				clientutils.AutoUpdateString(pkg.Package, "")}
 			if listCmdOptions.ShowLatestVersion {
 				row = append(row, pkg.LatestVersion)
@@ -272,6 +272,14 @@ func statusString(pkg list.PackageWithStatus) string {
 		return pkg.Status.Status
 	} else {
 		return "Not installed"
+	}
+}
+
+func messageString(pkg list.PackageWithStatus) string {
+	if pkg.Status != nil {
+		return pkg.Status.Reason
+	} else {
+		return ""
 	}
 }
 

--- a/cmd/glasskube/cmd/update.go
+++ b/cmd/glasskube/cmd/update.go
@@ -49,10 +49,6 @@ var updateCmd = &cobra.Command{
 			updater.WithStatusWriter(statuswriter.Spinner())
 		}
 
-		if updateCmdOptions.dryRun {
-
-		}
-
 		var tx *update.UpdateTransaction
 		var err error
 
@@ -115,10 +111,6 @@ var updateCmd = &cobra.Command{
 			printTransaction(*tx)
 			if !updateCmdOptions.Yes && !cliutils.YesNoPrompt("Do you want to apply these updates?", false) {
 				fmt.Fprintf(os.Stderr, "⛔ Update cancelled. No changes were made.\n")
-				cliutils.ExitSuccess()
-			}
-			if updateCmdOptions.dryRun {
-				fmt.Fprintf(os.Stderr, "📝 Dry run: No changes were made.\n")
 				cliutils.ExitSuccess()
 			}
 			updatedPackages, err := updater.ApplyBlocking(ctx, tx)

--- a/cmd/glasskube/cmd/update.go
+++ b/cmd/glasskube/cmd/update.go
@@ -30,7 +30,6 @@ import (
 var updateCmdOptions struct {
 	Version string
 	Yes     bool
-	dryRun  bool
 	OutputOptions
 	NamespaceOptions
 	KindOptions
@@ -273,8 +272,6 @@ func init() {
 	_ = updateCmd.RegisterFlagCompletionFunc("version", completeUpgradablePackageVersions)
 	updateCmd.PersistentFlags().BoolVarP(&updateCmdOptions.Yes, "yes", "y", false,
 		"do not ask for any confirmation")
-	updateCmd.PersistentFlags().BoolVar(&updateCmdOptions.dryRun, "dry-run", false,
-		"Do not update any packages but run all validations")
 	updateCmdOptions.OutputOptions.AddFlagsToCommand(updateCmd)
 	updateCmdOptions.KindOptions.AddFlagsToCommand(updateCmd)
 	updateCmdOptions.NamespaceOptions.AddFlagsToCommand(updateCmd)

--- a/cmd/glasskube/cmd/update.go
+++ b/cmd/glasskube/cmd/update.go
@@ -30,6 +30,7 @@ import (
 var updateCmdOptions struct {
 	Version string
 	Yes     bool
+	dryRun  bool
 	OutputOptions
 	NamespaceOptions
 	KindOptions
@@ -46,6 +47,10 @@ var updateCmd = &cobra.Command{
 		updater := update.NewUpdater(ctx)
 		if !rootCmdOptions.NoProgress {
 			updater.WithStatusWriter(statuswriter.Spinner())
+		}
+
+		if updateCmdOptions.dryRun {
+
 		}
 
 		var tx *update.UpdateTransaction
@@ -110,6 +115,10 @@ var updateCmd = &cobra.Command{
 			printTransaction(*tx)
 			if !updateCmdOptions.Yes && !cliutils.YesNoPrompt("Do you want to apply these updates?", false) {
 				fmt.Fprintf(os.Stderr, "⛔ Update cancelled. No changes were made.\n")
+				cliutils.ExitSuccess()
+			}
+			if updateCmdOptions.dryRun {
+				fmt.Fprintf(os.Stderr, "📝 Dry run: No changes were made.\n")
 				cliutils.ExitSuccess()
 			}
 			updatedPackages, err := updater.ApplyBlocking(ctx, tx)
@@ -272,6 +281,8 @@ func init() {
 	_ = updateCmd.RegisterFlagCompletionFunc("version", completeUpgradablePackageVersions)
 	updateCmd.PersistentFlags().BoolVarP(&updateCmdOptions.Yes, "yes", "y", false,
 		"do not ask for any confirmation")
+	updateCmd.PersistentFlags().BoolVar(&updateCmdOptions.dryRun, "dry-run", false,
+		"Do not update any packages but run all validations")
 	updateCmdOptions.OutputOptions.AddFlagsToCommand(updateCmd)
 	updateCmdOptions.KindOptions.AddFlagsToCommand(updateCmd)
 	updateCmdOptions.NamespaceOptions.AddFlagsToCommand(updateCmd)


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #899 
Fixes #899 

## 📑 Description
<!-- Add a brief description of the pr -->
This PR adds the feature to display the package installation error message in the `glasskube ist` command

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
It looks something like this:
```powershell

NAME                   STATUS         VERSION                                          AUTO-UPDATE  MESSAGE                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 REPOSITORY
argo-cd                Ready          v2.11.3+1                                        Enabled      60 manifests reconciled                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 glasskube (used)  
cert-manager           Not installed                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        glasskube
cloudnative-pg         Ready          v1.23.2+1                                        Enabled      15 manifests reconciled                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 glasskube (used)  
cyclops                Ready          v0.7.3+1                                         Enabled      17 manifests reconciled                                                                                                                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                       glasskube (used)  
ingress-nginx          Not installed                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        glasskube
k8sgpt-operator        Not installed                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        glasskube
keptn                  Not installed                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        glasskube
kube-prometheus-stack  Not installed                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        glasskube
kubernetes-dashboard   Failed         v2.7.0+1 (v2.7.0+2 desired, v2.7.0+2 available)  Enabled      flux: Helm install failed for release kubernetes-dashboard/kubernetes-dashboard-kubernetes-dashboard with chart kubernetes-dashboard@6.0.8: Unable to continue with install: Secret "kubernetes-dashboard-csrf" in namespace "kubernetes-dashboard" exists and cannot be imported into the current release: invalid ownership metadata; label validation error: key "app.kubernetes.io/managed-by" must equal "Helm": current value is "glasskube"; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "kubernetes-dashboard-kubernetes-dashboard"; annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "kubernetes-dashboard"  glasskube (used)  
quickwit               Not installed                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        glasskube
rabbitmq-operator      Ready          v2.9.0+1                                         Enabled      9 manifests reconciled                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  glasskube (used)  
sealed-secrets         Ready          v2.15.3+1                                        Enabled      flux: Helm install succeeded for release sealed-secrets-system/sealed-secrets-sealed-secrets.v1 with chart sealed-secrets@2.15.3                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        glasskube (used)  

```