### PR TITLE
fix(ui): avoid including repo parameter when only one present

### DIFF
--- a/internal/web/templates/pages/package.html
+++ b/internal/web/templates/pages/package.html
@@ -122,7 +122,7 @@
                       hx-swap="main"
                       hx-target="main"
                       hx-get="{{ .PackageHref }}"
-                      hx-include="#pkg-install-repository">
+                      {{ if gt (len .Repositories) 1 }}hx-include="#pkg-install-repository"{{ end }}>
                       {{ with $idx := .PackageIndex }}
                         {{ range $idx.Versions | Reversed }}
                           <option value="{{ .Version }}" {{ if eq .Version $.SelectedVersion }}selected{{ end }}>


### PR DESCRIPTION
…esent

<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #788

## 📑 Description
When the user selects a version, a request to reload the package detail page is triggered. With the `hx-include` attribute, additional query parameters can be added to this request, such that in a multi-repo environment, the selected repository is sent additionally to the selected version. The referred to element (`#pkg-install-repository`) however, doesn't exist when there is only one repository, and therefore there was an error logged to the browser console. This should be gone now. 

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->