### PR TITLE
fix(ui): discussion page for uninstalled namespaced packages

### DIFF
--- a/internal/web/discussions.go
+++ b/internal/web/discussions.go
@@ -92,7 +92,7 @@ func (s *server) handlePackageDiscussionPage(w http.ResponseWriter, r *http.Requ
 		}
 	}
 
-	pkgHref := util.GetPackageHref(d.pkg, d.manifest)
+	pkgHref := util.GetPackageHrefWithFallback(d.pkg, d.manifest)
 
 	err := s.templates.pkgDiscussionPageTmpl.Execute(w, s.enrichPage(r, map[string]any{
 		"Giscus":             giscus.Client().Config,


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->

## 📑 Description
This was not found til now, because we only show the discussion link for packages of the glasskube repo, which only since a short time includes a namespaced scoped package. The link in the `pkg-detail-header` to the discussion page was broken for uninstalled namespaced packages (it linked to `/packages/quickwit///discussion`), which lead to an `404` error, rerouting the client to the package overview page (this is a mechanism introduced to redirect from a namespaced package detail page to the overview page, after the package has been deleted). 
The fix makes the link go to `/packages/quickwit/-/-/discussion`. 

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->