### PR TITLE
chore(ui): update htmx to v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
         "@glasskube/theme": "0.1.1",
         "bootstrap": "5.3.3",
         "giscus": "^1.5.0",
-        "htmx.org": "1.9.12"
+        "htmx-ext-response-targets": "2.0.0",
+        "htmx-ext-sse": "2.2.0",
+        "htmx.org": "2.0.0"
       },
       "devDependencies": {
         "@commitlint/cli": "19.3.0",
@@ -1307,10 +1309,20 @@
         "node": ">=4"
       }
     },
+    "node_modules/htmx-ext-response-targets": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/htmx-ext-response-targets/-/htmx-ext-response-targets-2.0.0.tgz",
+      "integrity": "sha512-FrQRkCaytO+lwAz6TFs3kxL+ge6th2aBMbLNZspN5shkzu3oFu7+kleutt/9j1pOersZOae13fFabSnZDkg6cw=="
+    },
+    "node_modules/htmx-ext-sse": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/htmx-ext-sse/-/htmx-ext-sse-2.2.0.tgz",
+      "integrity": "sha512-gQBbwLb3uJJPeqH8jYYxSCbWpz30/10zXycPoHP9/hEFqCcmmiZ0DszkpbcUhyMxrTJQvNiJmFfGxGeWxl0Kng=="
+    },
     "node_modules/htmx.org": {
-      "version": "1.9.12",
-      "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-1.9.12.tgz",
-      "integrity": "sha512-VZAohXyF7xPGS52IM8d1T1283y+X4D+Owf3qY1NZ9RuBypyu9l8cGsxUMAG5fEAb/DhT7rDoJ9Hpu5/HxFD3cw=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.0.tgz",
+      "integrity": "sha512-N0r1VjrqeCpig0mTi2/sooDZBeQlp1RBohnWQ/ufqc7ICaI0yjs04fNGhawm6+/HWhJFlcXn8MqOjWI9QGG2lQ=="
     },
     "node_modules/human-signals": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "@glasskube/theme": "0.1.1",
     "bootstrap": "5.3.3",
     "giscus": "^1.5.0",
-    "htmx.org": "1.9.12"
+    "htmx.org": "2.0.0",
+    "htmx-ext-sse": "2.2.0",
+    "htmx-ext-response-targets": "2.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "19.3.0",

--- a/web/index.js
+++ b/web/index.js
@@ -1,6 +1,6 @@
-import 'htmx.org';
+import 'htmx.org/dist/htmx.esm';
 import './windowHtmx';
-import 'htmx.org/dist/ext/sse';
-import 'htmx.org/dist/ext/response-targets';
+import 'htmx-ext-sse';
+import 'htmx-ext-response-targets';
 import 'bootstrap';
 import 'giscus';

--- a/web/windowHtmx.js
+++ b/web/windowHtmx.js
@@ -1,4 +1,4 @@
 // This file is required to provide the global htmx variable.
 // Reference: https://htmx.org/docs/#webpack
-import htmx from 'htmx.org';
+import htmx from 'htmx.org/dist/htmx.esm';
 window.htmx = htmx;


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->

## 📑 Description
Relevant links:
* https://htmx.org/posts/2024-06-17-htmx-2-0-0-is-released/
* https://htmx.org/migration-guide-htmx-1/

Seems to me that everything is still working as before:
* swapping page contents
* receiving SSE events and triggering refreshes
* swapping errors to the correct container (`response-targets` extension)

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->