### PR TITLE
fix(client): ignore empty yaml objects

### DIFF
--- a/internal/clientutils/resources.go
+++ b/internal/clientutils/resources.go
@@ -38,6 +38,9 @@ func FetchResources(url string) ([]unstructured.Unstructured, error) {
 			}
 			return nil, fmt.Errorf("could not decode manifest %v: %w", url, err)
 		}
+		if len(object.Object) == 0 {
+			continue
+		}
 		resources = append(resources, object)
 	}
 	return resources, nil


### PR DESCRIPTION
Closes #952

## 📑 Description
Added condition to ignore appending yaml parsed object to the `resources` array if its empty

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
I tested my code by setting up a local package repository and adding `gateway-api` as an example to it. Now installation finishes successfully