### PR TITLE
fix(cli): improve bootstrap progressbar accuracy and error message

### DIFF
--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -254,9 +254,13 @@ func (c *BootstrapClient) applyManifests(
 
 	for _, obj := range checkWorkloads {
 		bar.Describe(fmt.Sprintf("Checking Status of %v (%v)", obj.GetName(), obj.GetKind()))
-		ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
-		defer cancel() // release the context in case checkWorkloadReady returned early
-		if err := c.checkWorkloadReady(ctx, obj.GetNamespace(), obj.GetName(), obj.GetKind()); err != nil {
+		var err error
+		func() {
+			ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+			defer cancel() // release the context in case checkWorkloadReady returned early
+			err = c.checkWorkloadReady(ctx, obj.GetNamespace(), obj.GetName(), obj.GetKind())
+		}()
+		if err != nil {
 			return err
 		}
 		_ = bar.Add(1)


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Ref #948 <!-- Issue # here -->

## 📑 Description
1. The progressbar would report an incorrect message most of the time because of the default throttle config
2. The error message in case a workload does not become ready was not helpful

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->