### PR TITLE
fix: add checking of response Content-Type

### DIFF
--- a/internal/contenttype/contenttype.go
+++ b/internal/contenttype/contenttype.go
@@ -1,0 +1,37 @@
+package contenttype
+
+import (
+	"fmt"
+	"strings"
+)
+
+type ContentType struct {
+	MediaType string
+	Chartset  string
+	Boundary  string
+}
+
+func ParseContentType(value string) (*ContentType, error) {
+	directives := strings.Split(value, ";")
+	result := ContentType{
+		MediaType: strings.TrimSpace(directives[0]),
+	}
+	if len(directives) > 1 {
+		for _, directive := range directives[1:] {
+			parts := strings.SplitN(strings.TrimSpace(directive), "=", 2)
+			if len(parts) == 2 {
+				switch parts[0] {
+				case "charset":
+					result.Chartset = parts[1]
+				case "boundary":
+					result.Boundary = parts[1]
+				default:
+					return nil, fmt.Errorf("content type has unknown directive %v", directive)
+				}
+			} else {
+				return nil, fmt.Errorf("content type has invalid directive %v", directive)
+			}
+		}
+	}
+	return &result, nil
+}

--- a/internal/contenttype/mediatype.go
+++ b/internal/contenttype/mediatype.go
@@ -1,0 +1,39 @@
+package contenttype
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+const (
+	MediaTypeJSON      = "application/json"
+	MediaTypeYAML      = "application/yaml"
+	MediaTypeTextYAML  = "text/yaml"
+	MediaTypeTextPlain = "text/plain"
+)
+
+func IsJsonOrYaml(response *http.Response) error {
+	return HasMediaType(response,
+		MediaTypeJSON,
+		MediaTypeYAML,
+		MediaTypeTextYAML,
+		MediaTypeTextPlain)
+}
+
+func HasMediaType(response *http.Response, acceptedContentTypes ...string) error {
+	contentType, err := ParseContentType(response.Header.Get("Content-Type"))
+	if err != nil {
+		return err
+	}
+	if contentType.MediaType == "" {
+		return nil
+	}
+	for _, t := range acceptedContentTypes {
+		if contentType.MediaType == t {
+			return nil
+		}
+	}
+	return fmt.Errorf("response has unacceptable media type: %v (acceptable media types are %v)",
+		contentType.MediaType, strings.Join(acceptedContentTypes, ", "))
+}


### PR DESCRIPTION
## 📑 Description
Currently, we don't show a useful error message if the response has a wrong content type. By parsing and checking the `Content-Type` header, we can show more useful error messages. 

Before:

> could not fetch package repository index: error converting YAML to JSON: yaml: line 228: mapping values are not allowed in this context


After: 

> could not fetch package repository index: could not decode https://github.com/jakepage91/packages/tree/add-caddy-ingress/packages/index.yaml: response has unacceptable media type: text/html (acceptable media types are application/json, application/yaml, text/yaml, text/plain)


In addition to the canonical media types `application/json` and `application/yaml`, the client also accepts `text/yaml` (non-standard but used by GitHub), `text/plain` (wrong but also used by GitHub) and empty `Content-Types` so a less useful error message may still be shown in those cases.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
I found #976 in the process, but that bug is unrelated to this change.