### PR TITLE
fix(cli): add handling of `--no-progress` flag for `glasskube bootstrap`

### DIFF
--- a/cmd/glasskube/cmd/bootstrap.go
+++ b/cmd/glasskube/cmd/bootstrap.go
@@ -109,6 +109,7 @@ func (o bootstrapOptions) asBootstrapOptions() bootstrap.BootstrapOptions {
 		Force:                   o.force,
 		CreateDefaultRepository: o.createDefaultRepository,
 		DryRun:                  o.DryRun,
+		NoProgress:              rootCmdOptions.NoProgress,
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #900 

## 📑 Description
When --no-progress flag is passed with bootstrap cmd then status message's and progress bar will not be shown on cli.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information