### PR TITLE
feat(cli): add `glasskube configure` showing an error for package with no value definitions

### DIFF
--- a/cmd/glasskube/cmd/configure.go
+++ b/cmd/glasskube/cmd/configure.go
@@ -59,11 +59,6 @@ func runConfigure(cmd *cobra.Command, args []string) {
 		cliutils.ExitWithError()
 	}
 
-	if len(pkg.GetSpec().Values) == 0 {
-		fmt.Fprintln(os.Stderr, "❌ This package has no configuration values")
-		cliutils.ExitWithError()
-	}
-
 	if configureCmdOptions.IsValuesSet() {
 		if values, err := configureCmdOptions.ParseValues(pkg.GetSpec().Values); err != nil {
 			fmt.Fprintf(os.Stderr, "❌ invalid values in command line flags: %v\n", err)
@@ -77,6 +72,9 @@ func runConfigure(cmd *cobra.Command, args []string) {
 			cliutils.ExitWithError()
 		} else if values, err := cli.Configure(*pkgManifest, pkg.GetSpec().Values); err != nil {
 			fmt.Fprintf(os.Stderr, "❌ error during configure: %v\n", err)
+			cliutils.ExitWithError()
+		} else if len(pkgManifest.ValueDefinitions) == 0 {
+			fmt.Fprintln(os.Stderr, "❌ this package has no configuration values:")
 			cliutils.ExitWithError()
 		} else {
 			pkg.GetSpec().Values = values

--- a/cmd/glasskube/cmd/configure.go
+++ b/cmd/glasskube/cmd/configure.go
@@ -59,6 +59,11 @@ func runConfigure(cmd *cobra.Command, args []string) {
 		cliutils.ExitWithError()
 	}
 
+	if len(pkg.GetSpec().Values) == 0 {
+		fmt.Fprintln(os.Stderr, "❌ This package has no configuration values")
+		cliutils.ExitWithError()
+	}
+
 	if configureCmdOptions.IsValuesSet() {
 		if values, err := configureCmdOptions.ParseValues(pkg.GetSpec().Values); err != nil {
 			fmt.Fprintf(os.Stderr, "❌ invalid values in command line flags: %v\n", err)

--- a/cmd/glasskube/cmd/configure.go
+++ b/cmd/glasskube/cmd/configure.go
@@ -74,7 +74,7 @@ func runConfigure(cmd *cobra.Command, args []string) {
 			fmt.Fprintf(os.Stderr, "❌ error during configure: %v\n", err)
 			cliutils.ExitWithError()
 		} else if len(pkgManifest.ValueDefinitions) == 0 {
-			fmt.Fprintln(os.Stderr, "❌ this package has no configuration values:")
+			fmt.Fprintln(os.Stderr, "❌ this package has no configuration values")
 			cliutils.ExitWithError()
 		} else {
 			pkg.GetSpec().Values = values

--- a/cmd/glasskube/cmd/configure.go
+++ b/cmd/glasskube/cmd/configure.go
@@ -70,11 +70,11 @@ func runConfigure(cmd *cobra.Command, args []string) {
 		if pkgManifest, err := manifest.GetInstalledManifestForPackage(ctx, pkg); err != nil {
 			fmt.Fprintf(os.Stderr, "❌ error getting installed manifest: %v\n", err)
 			cliutils.ExitWithError()
-		} else if values, err := cli.Configure(*pkgManifest, pkg.GetSpec().Values); err != nil {
-			fmt.Fprintf(os.Stderr, "❌ error during configure: %v\n", err)
-			cliutils.ExitWithError()
 		} else if len(pkgManifest.ValueDefinitions) == 0 {
 			fmt.Fprintln(os.Stderr, "❌ this package has no configuration values")
+			cliutils.ExitWithError()
+		} else if values, err := cli.Configure(*pkgManifest, pkg.GetSpec().Values); err != nil {
+			fmt.Fprintf(os.Stderr, "❌ error during configure: %v\n", err)
 			cliutils.ExitWithError()
 		} else {
 			pkg.GetSpec().Values = values


### PR DESCRIPTION
Closes #867 

## 📑 Description
`glasskube configure <package-without-configuration-values>`  will throw message as 'This package has no configuration values'
and exit.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->