### PR TITLE
chore(cli): revert accidental change of default `serve` port

### DIFF
--- a/cmd/glasskube/cmd/serve.go
+++ b/cmd/glasskube/cmd/serve.go
@@ -32,7 +32,7 @@ func (opts ServeCmdOptions) ServerOptions() web.ServerOptions {
 var (
 	serveCmdOptions = ServeCmdOptions{
 		host: "localhost",
-		port: 8050,
+		port: 8580,
 	}
 )
 


### PR DESCRIPTION
Accidentally changed in https://github.com/glasskube/glasskube/pull/1027