### PR TITLE
fix(package-operator): add validation of scope during package creation/update

### DIFF
--- a/internal/webhook/package_validator.go
+++ b/internal/webhook/package_validator.go
@@ -119,6 +119,13 @@ func (p *PackageValidatingWebhook) validateCreateOrUpdate(ctx context.Context, p
 		return err
 	}
 
+	// Scope validation
+	if (manifest.Scope == nil || *manifest.Scope == "Cluster") && pkg.IsNamespaceScoped() {
+		return errors.New("invalid scope, expected ClusterPackage but found Package")
+	} else if (manifest.Scope != nil && *manifest.Scope == "Namespaced") && !pkg.IsNamespaceScoped() {
+		return errors.New("invalid scope, expected Package but found ClusterPackage")
+	}
+
 	if err := manifestvalues.ValidatePackage(manifest, pkg); err != nil {
 		return err
 	}

--- a/internal/webhook/package_validator.go
+++ b/internal/webhook/package_validator.go
@@ -120,9 +120,9 @@ func (p *PackageValidatingWebhook) validateCreateOrUpdate(ctx context.Context, p
 	}
 
 	// Scope validation
-	if (manifest.Scope == nil || *manifest.Scope == "Cluster") && pkg.IsNamespaceScoped() {
+	if manifest.Scope.IsCluster() && pkg.IsNamespaceScoped() {
 		return errors.New("invalid scope, expected ClusterPackage but found Package")
-	} else if (manifest.Scope != nil && *manifest.Scope == "Namespaced") && !pkg.IsNamespaceScoped() {
+	} else if manifest.Scope.IsNamespaced() && !pkg.IsNamespaceScoped() {
 		return errors.New("invalid scope, expected Package but found ClusterPackage")
 	}
 


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #953 

## 📑 Description
Added scope validation for creation of Package/ClusterPackage resouces.
The only supported combinations of resource type - manifest scope:

- ClusterPackage - Cluster
- Package - Namespaced

Anything else should not lead to the creation of the resource.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
A check that compares the Manifest and Package's scope is added 