### PR TITLE
feat(cli): add support for filtering package list by name and namespace

### DIFF
--- a/cmd/glasskube/cmd/list.go
+++ b/cmd/glasskube/cmd/list.go
@@ -23,14 +23,18 @@ type ListCmdOptions struct {
 	ShowLatestVersion bool
 	ShowMessage       bool
 	More              bool
+	packageName       string
 	OutputOptions
 	KindOptions
+	NamespaceOptions
 }
 
 func (o ListCmdOptions) toListOptions() list.ListOptions {
 	return list.ListOptions{
 		OnlyInstalled: o.ListInstalledOnly,
 		OnlyOutdated:  o.ListOutdatedOnly,
+		PackageName:   o.packageName,
+		Namespace:     o.Namespace,
 	}
 }
 
@@ -39,12 +43,13 @@ var listCmdOptions = ListCmdOptions{
 }
 
 var listCmd = &cobra.Command{
-	Use:     "list",
+	Use:     "list [<package-name>]",
 	Aliases: []string{"ls", "l"},
 	Short:   "List packages",
 	Long: "List packages. By default, all available packages of the given repository are shown, " +
 		"as well as their installation status in your cluster.\nYou can choose to only show installed packages.",
 	PreRun: cliutils.SetupClientContext(true, &rootCmdOptions.SkipUpdateCheck),
+	Args:   cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
 		if listCmdOptions.More {
@@ -52,11 +57,20 @@ var listCmd = &cobra.Command{
 			listCmdOptions.ShowDescription = true
 			listCmdOptions.ShowMessage = true
 		}
+		if len(args) > 0 {
+			listCmdOptions.packageName = args[0]
+		}
+		if listCmdOptions.Kind == KindClusterPackage &&
+			(listCmdOptions.packageName != "" || listCmdOptions.Namespace != "") {
+			fmt.Fprintf(os.Stderr, "Argument [<package-name>] or flag [--namespace] not supported with kind %s.\n",
+				KindClusterPackage)
+			cliutils.ExitWithError()
+		}
 		lister := list.NewListerWithRepoCache(ctx)
 		var clPkgs []*list.PackageWithStatus
 		var pkgs []*list.PackagesWithStatus
 		var err error
-		if listCmdOptions.Kind != KindPackage {
+		if listCmdOptions.Kind != KindPackage && listCmdOptions.packageName == "" && listCmdOptions.Namespace == "" {
 			clPkgs, err = lister.GetClusterPackagesWithStatus(ctx, listCmdOptions.toListOptions())
 			handleListErr(len(clPkgs), err, "clusterpackages")
 		}
@@ -65,7 +79,8 @@ var listCmd = &cobra.Command{
 			handleListErr(len(pkgs), err, "packages")
 		}
 		noPkgs := len(pkgs) == 0 && listCmdOptions.Kind != KindClusterPackage
-		noClPkgs := len(clPkgs) == 0 && listCmdOptions.Kind != KindPackage
+		noClPkgs := len(clPkgs) == 0 && listCmdOptions.Kind != KindPackage &&
+			listCmdOptions.packageName == "" && listCmdOptions.Namespace == ""
 		if listCmdOptions.Output == OutputFormatJSON {
 			printPackageJSON(allPkgs(clPkgs, pkgs))
 		} else if listCmdOptions.Output == OutputFormatYAML {
@@ -75,13 +90,13 @@ var listCmd = &cobra.Command{
 				handleEmptyList("packages")
 			} else if len(pkgs) > 0 {
 				printPackageTable(pkgs)
-				if listCmdOptions.Kind != KindPackage {
-					fmt.Fprintln(os.Stderr, "")
-				}
 			}
 			if noClPkgs {
 				handleEmptyList("clusterpackages")
 			} else if len(clPkgs) > 0 {
+				if len(pkgs) > 0 {
+					fmt.Fprintln(os.Stderr, "")
+				}
 				printClusterPackageTable(clPkgs)
 			}
 		}
@@ -103,6 +118,7 @@ func init() {
 		"Show additional information about (cluster-)packages (like --show-description --show-latest)")
 	listCmdOptions.OutputOptions.AddFlagsToCommand(listCmd)
 	listCmdOptions.KindOptions.AddFlagsToCommand(listCmd)
+	listCmdOptions.NamespaceOptions.AddFlagsToCommand(listCmd)
 
 	listCmd.MarkFlagsMutuallyExclusive("show-description", "more")
 	listCmd.MarkFlagsMutuallyExclusive("show-latest", "more")
@@ -123,14 +139,7 @@ func handleListErr(listLen int, err error, resource string) {
 }
 
 func handleEmptyList(resource string) {
-	if listCmdOptions.ListOutdatedOnly {
-		fmt.Fprintf(os.Stderr, "All installed %s are up-to-date.\n", resource)
-	} else if listCmdOptions.ListInstalledOnly {
-		fmt.Fprintf(os.Stderr, "There are currently no %s installed in your cluster.\n"+
-			"Run \"glasskube help install\" to get started.\n", resource)
-	} else {
-		fmt.Fprintf(os.Stderr, "No %s found in the available repositories.\n", resource)
-	}
+	fmt.Fprintf(os.Stderr, "No %s found.\n", resource)
 }
 
 func allPkgs(clpkgs []*list.PackageWithStatus, pkgs []*list.PackagesWithStatus) []*list.PackageWithStatus {

--- a/pkg/list/lister.go
+++ b/pkg/list/lister.go
@@ -33,6 +33,8 @@ type ListOptions struct {
 	IncludePackageInfos bool
 	OnlyInstalled       bool
 	OnlyOutdated        bool
+	PackageName         string
+	Namespace           string
 }
 
 type lister struct {
@@ -101,7 +103,9 @@ func (l *lister) GetPackagesWithStatus(
 			}
 		}
 		hasIncludedItems := len(ls) > 0
-		if hasIncludedItems || (!options.OnlyInstalled && !options.OnlyOutdated) {
+		if hasIncludedItems ||
+			(!options.OnlyInstalled && !options.OnlyOutdated && options.Namespace == "" &&
+				(item.IndexItem.Name == options.PackageName || options.PackageName == "")) {
 			result = append(result, &PackagesWithStatus{
 				MetaIndexItem: *item.IndexItem,
 				Packages:      ls,
@@ -118,10 +122,13 @@ func clusterPackageShouldBeIncluded(item *result, options ListOptions) bool {
 
 func packageShouldBeIncluded(item *result, pkg *v1alpha1.Package, options ListOptions) bool {
 	if pkg != nil {
-		if !options.OnlyOutdated {
-			return true
+		if options.PackageName != "" && pkg.Spec.PackageInfo.Name != options.PackageName {
+			return false
 		}
-		return item.IndexItem != nil && pkg.Spec.PackageInfo.Version != item.IndexItem.LatestVersion
+		if options.OnlyOutdated && (item.IndexItem != nil && pkg.Spec.PackageInfo.Version == item.IndexItem.LatestVersion) {
+			return false
+		}
+		return true
 	}
 	return false
 }
@@ -172,7 +179,7 @@ func (l *lister) fetchRepoAndInstalled(ctx context.Context, options ListOptions,
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if err := l.pkgClient.Packages("").GetAll(ctx, &packages); err != nil {
+			if err := l.pkgClient.Packages(options.Namespace).GetAll(ctx, &packages); err != nil {
 				pkgErr = fmt.Errorf("could not fetch installed packages: %w", err)
 			}
 		}()


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #865

## 📑 Description
Adds the optional argument `<packageName>` and optional flag `--namespace`to the `list` cmd.

```
# shows a list of all Package resources with .Spec.PackageInfo.Name == "quickwit"
glasskube list quickwit
```
```
# shows a list of all Package resources in namespace "foo" with .Spec.PackageInfo.Name == "quickwit"
glasskube list quickwit --namespace foo
```
```
# shows an error message and calls ExitWithError
glasskube list --kind clusterpackage --namespace default
```
```
# shows an error message and calls ExitWithError
glasskube list quickwit --kind clusterpackage
```

## ✅ Checks
- [x] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
* The empty list error handling has been replaced with just one single message `No <resource> found.` for every case. Due to the different options to combine flags, sometimes multiple error messages are valid. It is hard to decide which one takes precedence. A simple single error message is less confusing instead.
* Introducing tests for list command. There is some complexity on how the flags interact with each other. Introducing new flags needs changes on retrieval logic and output logic. Some of these locations can be easily overlooked when not tested. Nevertheless, this requires some refactoring to make commands testable with injection of dependencies. So these changes need to be discussed first and are therefore not yet fully implemented.
  * Commands are created with a constructor, isolating them for testing and injecting necessary mock dependencies
    * e.g. fake k8s client (not yet fully implemented)
  * Commands need to return errors instead of exiting directly. Exiting logic could be handled in main calling the root command.

I would request some feedback if tests and changes like this are desired. Since the refactoring takes some effort.