### PR TITLE
fix: add repoclient invalidation

### DIFF
--- a/internal/repo/client/clientset.go
+++ b/internal/repo/client/clientset.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"reflect"
 	"sync"
 	"time"
 
@@ -22,7 +23,8 @@ type defaultClientsetClient struct {
 
 type defaultClientset struct {
 	client            defaultClientsetClient
-	clients           map[string]RepoClient
+	clients           map[string]repoClientWithState
+	clientAge         map[string]time.Time
 	repoWithNameMutex sync.Mutex
 	repoMutex         sync.Mutex
 	maxCacheAge       time.Duration
@@ -30,8 +32,22 @@ type defaultClientset struct {
 
 var _ RepoClientset = &defaultClientset{}
 
+type repoClientWithState struct {
+	client              RepoClient
+	lastCheckedRepoSpec time.Time
+	repo                v1alpha1.PackageRepository
+}
+
+func (s *repoClientWithState) lastCheckedRepoSpecAgo(maxAge time.Duration) bool {
+	return s.lastCheckedRepoSpec.Add(maxAge).After(time.Now())
+}
+
+func (s *repoClientWithState) checkRepoSpec(repo v1alpha1.PackageRepository) bool {
+	return reflect.DeepEqual(s.repo.Spec, repo.Spec)
+}
+
 func NewClientset(pkgClient adapter.PackageClientAdapter, k8sClient adapter.KubernetesClientAdapter) RepoClientset {
-	return NewClientsetWithMaxCacheAge(pkgClient, k8sClient, 5*time.Minute)
+	return NewClientsetWithMaxCacheAge(pkgClient, k8sClient, 30*time.Second)
 }
 
 func NewClientsetWithMaxCacheAge(pkgClient adapter.PackageClientAdapter, k8sClient adapter.KubernetesClientAdapter,
@@ -39,7 +55,8 @@ func NewClientsetWithMaxCacheAge(pkgClient adapter.PackageClientAdapter, k8sClie
 	return &defaultClientset{
 		client:      defaultClientsetClient{pkgClient, k8sClient},
 		maxCacheAge: maxCacheAge,
-		clients:     make(map[string]RepoClient),
+		clients:     make(map[string]repoClientWithState),
+		clientAge:   make(map[string]time.Time),
 	}
 }
 
@@ -52,9 +69,8 @@ func (d *defaultClientset) ForPackage(pkg ctrlpkg.Package) RepoClient {
 func (d *defaultClientset) ForRepoWithName(name string) RepoClient {
 	d.repoWithNameMutex.Lock()
 	defer d.repoWithNameMutex.Unlock()
-	if client, ok := d.clients[name]; ok {
-		// TODO: update client details if older than maxCacheAge
-		return client
+	if clientState, ok := d.clients[name]; ok && clientState.lastCheckedRepoSpecAgo(d.maxCacheAge) {
+		return clientState.client
 	}
 	if len(name) > 0 {
 		if repo, err := d.client.GetPackageRepository(context.TODO(), name); err != nil {
@@ -85,15 +101,19 @@ func (d *defaultClientset) Default() RepoClient {
 func (d *defaultClientset) ForRepo(repo v1alpha1.PackageRepository) RepoClient {
 	d.repoMutex.Lock()
 	defer d.repoMutex.Unlock()
-	if client, ok := d.clients[repo.Name]; ok {
-		// TODO: update client details if older than maxCacheAge
-		return client
+	if clientState, ok := d.clients[repo.Name]; ok && clientState.checkRepoSpec(repo) {
+		clientState.lastCheckedRepoSpec = time.Now()
+		return clientState.client
 	} else {
 		if headers, err := d.getAuthHeaders(repo); err != nil {
 			return &errorclient{fmt.Errorf("invalid auth config: %w", err)}
 		} else {
 			client := New(repo.Spec.Url, headers, d.maxCacheAge)
-			d.clients[repo.Name] = client
+			d.clients[repo.Name] = repoClientWithState{
+				client:              client,
+				lastCheckedRepoSpec: time.Now(),
+				repo:                repo,
+			}
 			return client
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #988 <!-- Issue # here -->

## 📑 Description
This PR adds checking of the repo spec when requesting a repo client from the clientset.
When requesting via name, it checks if the repo spec has been checked in the last 30 seconds (default) and checks again if it is older than that.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->