### PR TITLE
docs(website): added Series A IDP blog post to blog section

### DIFF
--- a/website/blog/2023-12-14-5-helm-shortcomings/index.mdx
+++ b/website/blog/2023-12-14-5-helm-shortcomings/index.mdx
@@ -11,6 +11,8 @@ image: https://cms.glasskube.eu/uploads/Goodbyehelm_7c21643ff8.png
 
 *5 reasons we are trying to build the next generation of deployment automation for Kubernetes.*
 
+<!-- truncate -->
+
 Glasskube is fully open-source. Support us by leaving a star: [⭐ `glasskube/glasskube` ⭐](https://github.com/glasskube/glasskube/)
 
 ## Introduction

--- a/website/blog/2024-02-01-technical-preview/index.mdx
+++ b/website/blog/2024-02-01-technical-preview/index.mdx
@@ -10,6 +10,7 @@ import Install from '../../src/partials/_install.mdx';
 
 *The aim of this post is to share our technical preview of how a cloud native package manager could work and what challenges need to be solved.*
 
+<!-- truncate -->
 
 Glasskube is fully open-source. Support us by leaving a star: [⭐ `glasskube/glasskube` ⭐](https://github.com/glasskube/glasskube/)
 

--- a/website/blog/2024-02-08-cncf-landscape/index.mdx
+++ b/website/blog/2024-02-08-cncf-landscape/index.mdx
@@ -12,6 +12,8 @@ import Install from '../../src/partials/_install.mdx';
 
 Featuring a GUI and a CLI. Glasskube packages are dependency aware, GitOps ready and can get automatic updates via a central public package repository.
 
+<!-- truncate -->
+
 Support us by leaving a star on GitHub: [⭐ `glasskube/glasskube` ⭐](https://github.com/glasskube/glasskube/)
 
 ## We got accepted into the CNCF Landscape

--- a/website/blog/2024-02-12-open-command/index.mdx
+++ b/website/blog/2024-02-12-open-command/index.mdx
@@ -10,6 +10,7 @@ import Install from '../../src/partials/_install.mdx';
 
 *Glasskube v0.0.2 was released on February 9th, just 9 days after initial technical preview release.*
 
+<!-- truncate -->
 
 Glasskube is fully open-source. Support us by leaving a star: [⭐ `glasskube/glasskube` ⭐](https://github.com/glasskube/glasskube/)
 

--- a/website/blog/2024-02-14-kubernetes-frontends/index.mdx
+++ b/website/blog/2024-02-14-kubernetes-frontends/index.mdx
@@ -8,6 +8,8 @@ tags: [ glasskube, kubernetes, frontends ]
 
 *In this blogpost we are reviewing Kubernetes Management Frontends and discuss how these tools are being built.*
 
+<!-- truncate -->
+
 # The Inner Workings of Kubernetes Management Frontends — A Software Engineer’s Perspective
 
 The rise of Kubernetes in recent years has led to an astonishing number of open-source Kubernetes management tools seemingly appearing out of nowhere.

--- a/website/blog/2024-02-27-release-package-updates/index.mdx
+++ b/website/blog/2024-02-27-release-package-updates/index.mdx
@@ -10,6 +10,7 @@ import Install from '../../src/partials/_install.mdx';
 
 *Glasskube v0.0.3 was released on February 27th, introducing package updates and many useful features for improved CLI and GUI experience.*
 
+<!-- truncate -->
 
 Glasskube is fully open-source. Support us by leaving a star: [⭐ `glasskube/glasskube` ⭐](https://github.com/glasskube/glasskube/)
 

--- a/website/blog/2024-03-22-release-0.1.0/index.mdx
+++ b/website/blog/2024-03-22-release-0.1.0/index.mdx
@@ -10,6 +10,7 @@ import Install from '../../src/partials/_install.mdx';
 
 *Glasskube v0.1.0 was released on March 21st, introducing new features like Dependency Management and Dark Mode as well as many useful features for an improved CLI and GUI experience.*
 
+<!-- truncate -->
 
 Glasskube is fully open-source. Support us by leaving a star: [⭐ `glasskube/glasskube` ⭐](https://github.com/glasskube/glasskube/)
 

--- a/website/blog/2024-03-26-discord-setup/index.mdx
+++ b/website/blog/2024-03-26-discord-setup/index.mdx
@@ -10,6 +10,8 @@ import Install from '../../src/partials/_install.mdx';
 
 It’s well-established that [Discord](https://discord.gg/SxH6KUCGH7) is a great platform for Developer communities. What’s less established are clear, best practices on how to configure a server from scratch to best serve a community of devs. If you are a community manager or Discord moderator, this blog post aims to give you the **definitive guide** to getting a working server that will feel welcoming, resourceful, and intuitive for all your community members. 
 
+<!-- truncate -->
+
 Configuring a **top-tier server** is not difficult at all, the [Glasskube server](https://discord.gg/SxH6KUCGH7) is an example of a **“less is more”** approach. Having said that, we will explore some additional intermediate and advanced practices that might make sense for some use cases. Let’s not waste any more time and jump straight in. 
 
 ## 1. Don't Reinvent the Wheel 🛞

--- a/website/blog/2024-04-04-contributor-guidelines/index.mdx
+++ b/website/blog/2024-04-04-contributor-guidelines/index.mdx
@@ -10,6 +10,8 @@ tags: [ glasskube ]
 
 As an open-source project maintainer, you should be obsessed with **Developer Experience**. I don’t need to convince you that the [README.md](https://github.com/glasskube/glasskube/tree/main) needs to be clear and informative. Everybody knows how great documentation can elevate a project. Having a top-notch [CONTRIBUTING.md](https://github.com/glasskube/glasskube/blob/main/CONTRIBUTING.md) file is the missing piece to retain the open-source contributors you attract. 
 
+<!-- truncate -->
+
 The CONTRIBUTING.md file should not be confused with a tutorial or a project guide, it’s `reference material` for developers who want to understand what work is available and how to get involved quickly. 
 
 Make sure your guidelines are: 

--- a/website/blog/2024-04-26-beta-launch-blog/index.mdx
+++ b/website/blog/2024-04-26-beta-launch-blog/index.mdx
@@ -13,6 +13,8 @@ tags: [ glasskube ]
 
 [Glasskube](https://github.com/glasskube/glasskube) has been on a tear lately. 🚀
 
+<!-- truncate -->
+
 Having only just launched officially last February and having been received incredibly positively by the cloud native and Kubernetes community we are happy to announce that Glasskube Beta is upon us. 
 The Glasskube team as well as the growing community of Glasskube open source contributors have rallied and combined forces to bring the **Beta release** sooner than expected. Everybody involved deserves a huge round of applause. 👏
 

--- a/website/blog/2024-05-20-devops/index.mdx
+++ b/website/blog/2024-05-20-devops/index.mdx
@@ -12,10 +12,11 @@ import Install from '../../src/partials/_install.mdx';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-
 ![article-thumbnail](https://github.com/glasskube/glasskube/assets/38757612/54324401-9b0f-4faf-a7c1-beea346057de)
 
 When I look at younger generations that didn’t grow up largely offline like I did, I feel slightly sorry for them. I’m in my mid-thirties, so I know what it was like to grow up tapping into [dial-up](https://en.wikipedia.org/wiki/Dial-up_Internet_access) internet as quickly as possible (to avoid blocking the phone line for too long) to access a couple of Wikipedia pages to do my homework and not feel like anything was missing. By personally living through the ascendence of the personal computer we all have in our pockets I feel, not immune, but better equipped to use it to my advantage and not fall victim to its false promises of limitless bliss and fulfillment simply for being more “[connected](https://www.newyorker.com/news/the-new-yorker-interview/jonathan-haidt-wants-you-to-take-away-your-kids-phone)”.
+
+<!-- truncate -->
 
 On the other hand, there is another revolution that **I was not directly a part of**, the revolution that happened in the IT departments worldwide across the 00s in the aftermath of the now-legendary [Flickr](https://www.youtube.com/watch?v=LdOe18KhtT4) talk at the O’Reilly Velocity conference in 2009. An event that put `DevOps` on the map and showed a future that could pivot from the siloed, slow-moving [ITIL](https://en.wikipedia.org/wiki/ITIL)-based organization to something better.
 

--- a/website/blog/2024-07-02-quickwit/index.mdx
+++ b/website/blog/2024-07-02-quickwit/index.mdx
@@ -16,6 +16,8 @@ import TabItem from '@theme/TabItem';
 
 Distributed application troubleshooting can be a nightmare. Unless you have the budget for expensive proprietary monitoring SaaS solutions or the expertise to run and maintain an complex ELK stack you might feel as if you are stuck in a cave without a flashlight.
 
+<!-- truncate -->
+
 Luckily, viable open-source alternatives like [Quickwit](https://quickwit.io/) are here to come to the rescue. By weaving together existing tooling for log and trace ingesting as well as pairing well with dashboard and visualisation tools such as Grafana and Jaeger. And sandwiching powerful indexing storage and search capabilities in between. Even if the tool sounds new, it won’t be for long.
 
 We recently integrated Quickwit with [Glasskube](https://github.com/glasskube/glasskube) and it’s available to be easily deployed to your cluster. I spoke directly with Quickwit co-founder [François Massot](https://www.linkedin.com/in/fran%C3%A7ois-massot-473006b/) to get the insider scoop, and to learn how the tool works. Let's dive in!

--- a/website/blog/2024-08-06-IDP/index.mdx
+++ b/website/blog/2024-08-06-IDP/index.mdx
@@ -1,0 +1,109 @@
+---
+slug: series-a-idp
+title: Why integrating an IDP for Series A companies doesn't make sense
+description: "A blog post exploring why Series A startup should avoid the internal developer platform (IDP) hype train"
+authors: [ pmig, jpage ]
+tags: [ glasskube, idp ]
+image: https://github.com/user-attachments/assets/0a3696b1-3367-422b-bdee-fb6272389535
+---
+
+import CustomGitHubButton from '@site/src/components/buttons/CustomGitHubButton.tsx';
+import Install from '../../src/partials/_install.mdx';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+![thumbnail](https://github.com/user-attachments/assets/0a3696b1-3367-422b-bdee-fb6272389535)
+
+CTO of a Series A company? Before reading on, just give yourself a quick pat on the back. What you and your team have done so far is no easy task, so fair play to you.
+
+<!-- truncate -->
+
+Realistically though, the work is far from done. Many scaling and growth decisions lay ahead and probably more questions than clear convictions.
+
+You might be tempted to preemptively adopt tooling and processes, positioning your engineering team for the potential growth to come. In this piece we’ll explain why you are more likely to succeed by doubling down on what brought you to this point over adopting new processes or fancy Internal Developer platforms.
+
+### Setting the right foundations
+
+Series A companies are exciting environments to be in, usually a reasonable influx of new faces join the company, processes are increasingly standardised and overall, there is a progressive company-wide maturity that is starting to take hold. The instinct to mature the engineering org is understandable but nonetheless ill placed.
+
+No level of maturity or sophisticated tooling can compensate for a lack of Product Market Fit (PMF). Validating PMF across markets should be top of mind at this stage above all else. Elusive as it may be, your best chance of achieving it is staying agile, delivering rapidly and maintaining tight feedback loops.
+
+The idea of planning for future scalability might be appealing, especially with the buzz around platform engineering and the availability of ready-made internal developer platform (IDP) solutions. However, it’s crucial to understand why these options might not be the right choice for you right now. Let’s delve into the reasons why an IDP isn’t the change you think you need.
+
+![platform-engineering](https://github.com/user-attachments/assets/887ad190-4e37-4b8e-afb2-bce58039695c)
+
+### What is an IDP?
+
+An IDP is a self-service layer build on top of your organisation’s infrastructure, that enables your developer teams to deploy and manage applications without the need to have in-depth infrastructure knowledge or relying on the help of traditional infrastructure engineers. It aims to provide consistency, automation, and speed by standardizing workflows and environments as the organization grows.
+
+Think of an IDP as an internal product maintained by DevOps or Platform engineers, who essentially serve their own customer base, your development teams. To understand why adopting an IDP might be counterproductive for a Series A company, it’s essential to understand why IDPs emerged in the first place.
+
+As companies expand, so do their engineering teams. In large enterprises, maintaining code quality, keeping up with infrastructure requirements and sustaining deployment velocity is hard if operations teams can’t keep up. IDPs were designed to remove reliance on traditional operations teams, to rely on a platform that actively evolves to fit their needs.
+
+> _A few assumptions are important to point out here:_
+
+> You have the resources to maintain a completely new product (the IDP). **_You probably don’t._**
+
+> You have already scaled the engineering org and now need to optimise it. **_You probably haven’t and don’t need to._**
+
+![graph-1](https://github.com/user-attachments/assets/c5bad338-9087-4641-a100-65193962b3e4)
+
+startup priorities
+
+### What should Series A companies care about?
+
+Before going on about the types of tools and processes your shouldn’t care about, let’s take a more proactive approach and focus on things that will actually move the needle.
+
+#### The right team
+
+You need a group of people who can run themselves, have the expertise to automate infrastructure related tasks and are open to working in flexible and not overly standardised structures. They should be the ones who propose changes and implement them as needed.
+
+#### Finding and validating PMF
+
+By the time you are at a Series A level you have surely caught the scent of where you might find PMF. Do not let up, ship fast and communicate intensely with your target audience to validate your market assumptions. There is no reward in finding a gap in the market alone, you have to occupy it. Maintain development velocity to increasingly occupy the gap you have identified.
+
+#### Staying agile and flexible
+
+The engineering team, like all teams within the company, should be unequivocally aligned with one primary objective: enabling the business. The engineering team sits at the centre of a short but tightly knit feedback loop which includes sales, feature ideation, feature development, deployment, and gathering feedback. Ideally, the sales team is working flat out, and customer service is maintaining close contact with customer. For the engineering team to keep it’s end of the bargain, it has to stay flexible and agile, ready to respond quickly the other teams inputs.
+
+![graph-2](https://github.com/user-attachments/assets/72e461f2-fa49-4b44-88d5-313eb239a0c9)
+
+#### Focusing on customer facing products only
+
+Even though we’ve mentioned this before, it’s important to emphasise that an IDP is a fully-fledged product that needs to be created, maintained, and evolved to meet the changing needs of internal developers over time. Focusing on an internal product like this can detract from the attention and resources needed for your customer-facing products, which ultimately bring you in closer contact with PMF and customer satisfaction.
+
+#### Building the right culture
+
+This is a point that should not be overlooked. Regardless of your company’s stage, evolution is always and ongoing dynamic. A culture of alignment, healthy communication principles, and a focus on shared goals is the bedrock that must serve as a base for the discussions about architecture, tooling, and process definitions which enable said evolution. Collective buy-in can only happen if a meaningful shared culture exists.
+
+### What should a Series A CTO not be thinking about?
+
+It’s not un-common to hear people report having learned more from their bad managers than from their good ones. Why might that be? Because knowing what not to do can sometimes be more important the the opposite.
+
+#### Don’t maintaining internal products
+
+Any time spend not addressing requests from your product and sales teams and hopefully your customers is time wasted.
+
+Any time spend that doesn’t involve delivering a better experience than your competitors is a mistake.
+
+#### Avoid large engineering teams
+
+Just because the rest of the company is growing doesn’t mean the engineering team has to expand at the same rate. Those who praise the magic that can be harnessed by keeping [engineering teams small](https://medium.com/r/?url=https%3A%2F%2Fposthog.com%2Fnewsletter%2Fsmall-teams) are on to something.
+
+At this stage, as you may be bringing on your first DevOps engineers, ensure they integrate into a compact, developer-focused team with a single leader to avoid unnecessary managerial layers, allowing for open communication and quick decisions to be made.
+
+#### Forget about perfection
+
+It’s not news to you that shipping quickly and continuously improving over time is the best way to build a product that eventually wins market share and meets customer expectations. Why would scaling engineering teams be any different? Trying to implement an Internal Developer Platform too soon runs contrary to those principles. There will be a time when you will build one out but let that process happen iteratively in a gradual manner. You have others things to worry about in the meantime.
+
+### You are on the right track
+
+Reaching a Series A funding round is not the end goal for anybody, you have a lot of room for growth. PMF is more than likely not locked down and occasional engineering bottlenecks should be dealt with on a case by case basis. Now is the time to double down on the strengths and keep on improving you capacity to identify your customer and increase user satisfaction.
+
+There will be a time to look inwards and improve internal engineering processes, and IDP might make sense in the future, but at this moment in time your limited engineering output should be laser focused on staying lean.
+
+Implementing internal products that don’t directly enable the business too soon have the potential for dire consequences. Approximately 35% of series A funded startups [fail](https://medium.com/r/?url=https%3A%2F%2Fluisazhou.com%2Fblog%2Fstartup-failure-statistics%2F%23%3A~%3Atext%3DIf%2520a%2520startup%2520makes%2520it%2Cof%252012%2520to%252018%2520months.) before Series B, a lot is at stake.
+
+No need to worry though, you have made it this far, don’t give into platform engineering FOMO, put you head down and keep doing what you’ve been doing, because it’s working.
+
+> We would love to hear from you, what are your thoughts? when is an organization really ready for an IDP?


### PR DESCRIPTION
Added the blog. 

I found this issue that added support for canonical links [here](https://github.com/facebook/docusaurus/issues/2603), even though I didn't find clear instructions in the official docs. 
## 📑 Description
<!-- Add a brief description of the pr -->

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->