### PR TITLE
feat(package-operator): add package repository validating webhook

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -37,6 +37,9 @@ resources:
   kind: PackageRepository
   path: github.com/glasskube/glasskube/api/v1alpha1
   version: v1alpha1
+  webhooks:
+    validation: true
+    webhookVersion: v1
 - api:
     crdVersion: v1
     namespaced: true

--- a/cmd/cert-manager/main.go
+++ b/cmd/cert-manager/main.go
@@ -21,7 +21,7 @@ var (
 	webhookConfigName = "glasskube-validating-webhook-configuration"
 	namespace         = "glasskube-system"
 	certDir           = ""
-	webhookNames      = []string{"vpackage.kb.io", "vclusterpackage.kb.io"}
+	webhookNames      = []string{"vpackage.kb.io", "vclusterpackage.kb.io", "vpackagerepository.kb.io"}
 
 	log logr.Logger
 

--- a/cmd/package-operator/main.go
+++ b/cmd/package-operator/main.go
@@ -157,6 +157,14 @@ func main() {
 			os.Exit(1)
 		}
 	}
+	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
+		if err = (&webhook.PackageRepositoryValidatingWebhook{
+			Client: mgr.GetClient(),
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "PackageRepository")
+			os.Exit(1)
+		}
+	}
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -14,6 +14,7 @@ patches:
   - path: patches/webhook_in_packages.yaml
   - path: patches/webhook_in_clusterpackages.yaml
 #- path: patches/webhook_in_packageinfos.yaml
+  - path: patches/webhook_in_packagerepositories.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.

--- a/config/crd/patches/cainjection_in_packagerepositories.yaml
+++ b/config/crd/patches/cainjection_in_packagerepositories.yaml
@@ -1,0 +1,7 @@
+# The following patch adds a directive for certmanager to inject CA into the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
+  name: packagerepositories.packages.glasskube.dev

--- a/config/crd/patches/webhook_in_packagerepositories.yaml
+++ b/config/crd/patches/webhook_in_packagerepositories.yaml
@@ -1,0 +1,16 @@
+# The following patch enables a conversion webhook for the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: packagerepositories.packages.glasskube.dev
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert
+      conversionReviewVersions:
+      - v1

--- a/config/webhook-local/webhook_manifests_patch.yaml
+++ b/config/webhook-local/webhook_manifests_patch.yaml
@@ -11,3 +11,7 @@ webhooks:
       service:
         port: 9443
     name: vclusterpackage.kb.io
+  - clientConfig:
+      service:
+        port: 9443
+    name: vpackagerepository.kb.io

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -46,3 +46,23 @@ webhooks:
     resources:
     - packages
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-packages-glasskube-dev-v1alpha1-packagerepository
+  failurePolicy: Fail
+  name: vpackagerepository.kb.io
+  rules:
+  - apiGroups:
+    - packages.glasskube.dev
+    apiVersions:
+    - v1alpha1
+    operations:
+    - UPDATE
+    - DELETE
+    resources:
+    - packagerepositories
+  sideEffects: None

--- a/internal/webhook/errors.go
+++ b/internal/webhook/errors.go
@@ -4,11 +4,13 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/glasskube/glasskube/api/v1alpha1"
 	"github.com/glasskube/glasskube/internal/dependency"
 )
 
 var ErrInvalidObject = errors.New("validator called with unexpected object type")
 var ErrDependencyConflict = errors.New("dependency conflict")
+var ErrPackagesInstalled = errors.New("dependent package(s) installed")
 
 func newConflictError(conflicts dependency.Conflicts) error {
 	return fmt.Errorf("%w: %v", ErrDependencyConflict, conflicts)
@@ -16,6 +18,10 @@ func newConflictError(conflicts dependency.Conflicts) error {
 
 func newConflictErrorDelete(err error) error {
 	return fmt.Errorf("%w: %w", ErrDependencyConflict, err)
+}
+
+func newErrPackagesInstalled(packageInfoSpecs []v1alpha1.PackageInfoSpec) error {
+	return fmt.Errorf("%w: %v", ErrPackagesInstalled, packageInfoSpecs)
 }
 
 func isErrDependencyConflict(err error) bool { return errors.Is(err, ErrDependencyConflict) }

--- a/internal/webhook/packagerepository_webhook.go
+++ b/internal/webhook/packagerepository_webhook.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+
+	"github.com/glasskube/glasskube/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type PackageRepositoryValidatingWebhook struct {
+	client.Client
+}
+
+// SetupWebhookWithManager will setup the manager to manage the webhooks
+func (p *PackageRepositoryValidatingWebhook) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&v1alpha1.PackageRepository{}).
+		WithValidator(p).
+		Complete()
+}
+
+// +kubebuilder:webhook:path=/validate-packages-glasskube-dev-v1alpha1-packagerepository,mutating=false,failurePolicy=fail,sideEffects=None,groups=packages.glasskube.dev,resources=packagerepositories,verbs=update;delete,versions=v1alpha1,name=vpackagerepository.kb.io,admissionReviewVersions=v1
+
+var _ webhook.CustomValidator = &PackageRepositoryValidatingWebhook{}
+
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type
+func (p *PackageRepositoryValidatingWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	log := ctrl.LoggerFrom(ctx)
+	if repo, ok := obj.(*v1alpha1.PackageRepository); ok {
+		log.Info("validate create", "name", repo.Name)
+		return nil, nil
+	}
+	return nil, ErrInvalidObject
+}
+
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type
+func (p *PackageRepositoryValidatingWebhook) ValidateUpdate(ctx context.Context, oldObj runtime.Object, newObj runtime.Object) (admission.Warnings, error) {
+	log := ctrl.LoggerFrom(ctx)
+	if oldRepo, ok := oldObj.(*v1alpha1.PackageRepository); ok {
+		if newRepo, ok := newObj.(*v1alpha1.PackageRepository); ok {
+			log.Info("validate update", "name", newRepo.Name)
+			if oldRepo.Spec.Url != newRepo.Spec.Url {
+				return nil, p.validateUpdateOrDelete(ctx, oldRepo)
+			}
+		}
+	}
+	return nil, ErrInvalidObject
+}
+
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type
+func (p *PackageRepositoryValidatingWebhook) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	log := ctrl.LoggerFrom(ctx)
+	if repo, ok := obj.(*v1alpha1.PackageRepository); ok {
+		log.Info("validate delete", "name", repo.Name)
+		return nil, p.validateUpdateOrDelete(ctx, repo)
+	}
+	return nil, ErrInvalidObject
+}
+
+func (p *PackageRepositoryValidatingWebhook) validateUpdateOrDelete(ctx context.Context, repo *v1alpha1.PackageRepository) error {
+	var pkgLs v1alpha1.PackageInfoList
+	if err := p.Client.List(ctx, &pkgLs); err != nil {
+		return err
+	}
+	var repoPkgLs []v1alpha1.PackageInfoSpec
+	for _, item := range pkgLs.Items {
+		if item.Spec.RepositoryName == repo.Name {
+			repoPkgLs = append(repoPkgLs, item.Spec)
+		}
+	}
+	if len(repoPkgLs) > 0 {
+		return newErrPackagesInstalled(repoPkgLs)
+	}
+	return nil
+}

--- a/internal/webhook/packagerepository_webhook_test.go
+++ b/internal/webhook/packagerepository_webhook_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+
+	"github.com/glasskube/glasskube/api/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newPackageRepositoryValidatingWebhook(objects ...client.Object) *PackageRepositoryValidatingWebhook {
+	fakeClient := fake.NewClientBuilder().
+		WithObjects(objects...).
+		Build()
+	return &PackageRepositoryValidatingWebhook{
+		Client: fakeClient,
+	}
+}
+
+var (
+	glasskubev1Repo = v1alpha1.PackageRepository{
+		ObjectMeta: v1.ObjectMeta{Name: "glasskube"},
+		Spec:       v1alpha1.PackageRepositorySpec{Url: "https://packages.dl.glasskube.dev/packages"},
+	}
+	glasskubev2Repo = v1alpha1.PackageRepository{
+		ObjectMeta: v1.ObjectMeta{Name: glasskubev1Repo.Name},
+		Spec:       v1alpha1.PackageRepositorySpec{Url: "https://packages.dl.glasskube.new/packages"},
+	}
+	hinterseerv1Package = v1alpha1.Package{
+		ObjectMeta: v1.ObjectMeta{Name: "hinterseer"},
+		Spec:       v1alpha1.PackageSpec{PackageInfo: v1alpha1.PackageInfoTemplate{Name: "hinterseer", RepositoryName: glasskubev1Repo.Name}},
+	}
+	hinterseerv1PackageInfo = v1alpha1.PackageInfo{
+		ObjectMeta: v1.ObjectMeta{Name: "glasskube--hinterseer--v0.8.1--5"},
+		Spec:       v1alpha1.PackageInfoSpec{Name: hinterseerv1Package.Name, RepositoryName: hinterseerv1Package.Spec.PackageInfo.RepositoryName, Version: "v0.8.1+5"},
+	}
+	metalkubev1Repo = v1alpha1.PackageRepository{
+		ObjectMeta: v1.ObjectMeta{Name: "metalkube"},
+		Spec:       v1alpha1.PackageRepositorySpec{Url: "https://packages.dl.metalkube.dev/packages"},
+	}
+	metalkubev2Repo = v1alpha1.PackageRepository{
+		ObjectMeta: v1.ObjectMeta{Name: metalkubev1Repo.Name},
+		Spec:       v1alpha1.PackageRepositorySpec{Url: "https://packages.dl.metalkube.new/packages"},
+	}
+)
+
+var _ = Describe("PackageRepositoryValidatingWebhook", Ordered, func() {
+	BeforeAll(func() {
+		err := v1alpha1.AddToScheme(scheme.Scheme)
+		Expect(err).NotTo(HaveOccurred())
+	})
+	Context("ValidateDelete", func() {
+		When("no packages installed", func() {
+			It("should not return an error", func(ctx context.Context) {
+				webhook := newPackageRepositoryValidatingWebhook(&metalkubev1Repo)
+				_, err := webhook.ValidateDelete(ctx, &metalkubev1Repo)
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+		When("packages installed", func() {
+			It("should return an error", func(ctx context.Context) {
+				webhook := newPackageRepositoryValidatingWebhook(&glasskubev1Repo, &hinterseerv1Package, &hinterseerv1PackageInfo)
+				_, err := webhook.ValidateDelete(ctx, &glasskubev1Repo)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(ErrPackagesInstalled))
+			})
+		})
+	})
+	Context("ValidateUpdate", func() {
+		When("url update and no packages installed", func() {
+			It("should not return an error", func(ctx context.Context) {
+				webhook := newPackageRepositoryValidatingWebhook(&metalkubev1Repo)
+				_, err := webhook.ValidateUpdate(ctx, &metalkubev1Repo, &metalkubev2Repo)
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+		When("url update and packages installed", func() {
+			It("should return an error", func(ctx context.Context) {
+				webhook := newPackageRepositoryValidatingWebhook(&glasskubev1Repo, &hinterseerv1Package, &hinterseerv1PackageInfo)
+				_, err := webhook.ValidateUpdate(ctx, &glasskubev1Repo, &glasskubev2Repo)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(ErrPackagesInstalled))
+			})
+		})
+	})
+})


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #871 

## 📑 Description
Adds a validating webhook for the package repository resource
* Upon deletion of a repository, or update of the URL of a repository, the following validation is performed:
  * If no packages are installed, the delete/update proceeds as normal. If packages are installed, an error with the list of installed packages is shown
  * ```
    k delete packagerepositories.packages.glasskube.dev test
    Error from server (Forbidden): admission webhook "vpackagerepository.kb.io" denied the request: dependent package(s) installed: [{ingress-nginx v1.9.5+1 test}]
    ```

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->