### PR TITLE
fix(package-operator): always set the correct type for HelmRepositories

### DIFF
--- a/api/v1alpha1/package_manifest.go
+++ b/api/v1alpha1/package_manifest.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"strings"
+
 	"github.com/invopop/jsonschema"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
@@ -31,6 +33,10 @@ type HelmManifest struct {
 	ChartVersion string `json:"chartVersion" jsonschema:"required"`
 	// Values that should be used for the helm release
 	Values *JSON `json:"values,omitempty"`
+}
+
+func (obj HelmManifest) IsOCIRepository() bool {
+	return strings.HasPrefix(obj.RepositoryUrl, "oci://")
 }
 
 type KustomizeManifest struct {

--- a/internal/manifest/helm/flux/adapter.go
+++ b/internal/manifest/helm/flux/adapter.go
@@ -137,6 +137,11 @@ func (a *FluxHelmAdapter) ensureHelmRepository(
 	}
 	log := ctrl.LoggerFrom(ctx).WithValues("HelmRepository", helmRepository.Name)
 	result, err := createOrUpdateWithRetry(ctx, a.Client, &helmRepository, func() error {
+		if manifest.Helm.IsOCIRepository() {
+			helmRepository.Spec.Type = sourcev1.HelmRepositoryTypeOCI
+		} else {
+			helmRepository.Spec.Type = sourcev1.HelmRepositoryTypeDefault
+		}
 		helmRepository.Spec.URL = manifest.Helm.RepositoryUrl
 		helmRepository.Spec.Interval = metav1.Duration{Duration: 1 * time.Hour}
 		labels.SetManaged(&helmRepository)


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #1087 

## 📑 Description
When pulling from an OCI repo, flux needs the type of the helm repository to be set to "oci". We use the URL scheme as a heuristic to determine the repo type on the fly: if the url starts with "oci://" we assume the type "oci", otherwise "default".

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
Reference https://fluxcd.io/flux/components/source/helmrepositories/#helm-oci-repository