### PR TITLE
chore: update Go version to 1.23.0 and golangci-lint to 1.60.1

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
       - name: Set up node
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - main
-      - "[0-9]+.[0-9]+.x"
+      - '[0-9]+.[0-9]+.x'
     tags:
-      - "v?[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+"
-      - "v?[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+"
-      - "v?[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
+      - 'v?[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+'
+      - 'v?[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+'
+      - 'v?[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
   workflow_dispatch:
 
 jobs:
@@ -54,18 +54,18 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5
         with:
-          go-version: "1.22.x"
+          go-version: '1.23.x'
       - name: Set up node
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
         with:
-          node-version: "20.9"
+          node-version: '20.9'
           cache: npm
       - name: Install dependencies
         run: npm ci
       - name: Set up kubectl
         uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f # v4
         with:
-          version: "v1.29.1"
+          version: 'v1.29.1'
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22 as builder
+FROM golang:1.23 as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ test: manifests generate fmt lint-go envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" $(GOCMD) test ./... -coverprofile cover.out
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
-GOLANGCI_LINT_VERSION ?= v1.54.2
+GOLANGCI_LINT_VERSION ?= v1.60.1
 golangci-lint:
 	@[ -f $(GOLANGCI_LINT) ] || { \
 	set -e ;\

--- a/cmd/glasskube/cmd/describe.go
+++ b/cmd/glasskube/cmd/describe.go
@@ -17,13 +17,14 @@ import (
 	"github.com/glasskube/glasskube/internal/manifestvalues"
 	repoclient "github.com/glasskube/glasskube/internal/repo/client"
 	"github.com/glasskube/glasskube/internal/semver"
+	"github.com/glasskube/glasskube/internal/util"
 	"github.com/glasskube/glasskube/pkg/client"
 	"github.com/glasskube/glasskube/pkg/condition"
 	"github.com/glasskube/glasskube/pkg/describe"
 	"github.com/spf13/cobra"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/renderer"
-	"github.com/yuin/goldmark/util"
+	goldmarkutil "github.com/yuin/goldmark/util"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/yaml"
 )
@@ -299,7 +300,7 @@ func referencesAsMap(
 
 func printValueConfigurations(w io.Writer, values map[string]v1alpha1.ValueConfiguration) {
 	for name, value := range values {
-		fmt.Fprintf(w, " * %v: %v\n", name, manifestvalues.ValueAsString(value))
+		util.Must(fmt.Fprintf(w, " * %v: %v\n", name, manifestvalues.ValueAsString(value)))
 	}
 }
 
@@ -307,15 +308,15 @@ func printMarkdown(w io.Writer, text string) {
 	md := goldmark.New(
 		goldmark.WithRenderer(renderer.NewRenderer(
 			renderer.WithNodeRenderers(
-				util.Prioritized(cliutils.MarkdownRenderer(), 1000),
+				goldmarkutil.Prioritized(cliutils.MarkdownRenderer(), 1000),
 			),
 		)),
 	)
 	var buf bytes.Buffer
 	if err := md.Convert([]byte(text), &buf); err != nil {
-		fmt.Fprintln(w, text)
+		util.Must(fmt.Fprintln(w, text))
 	} else {
-		fmt.Fprintln(w, strings.TrimSpace(buf.String()))
+		util.Must(fmt.Fprintln(w, strings.TrimSpace(buf.String())))
 	}
 }
 

--- a/cmd/glasskube/cmd/update.go
+++ b/cmd/glasskube/cmd/update.go
@@ -9,6 +9,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/glasskube/glasskube/internal/clientutils"
+	"github.com/glasskube/glasskube/internal/util"
 
 	"github.com/glasskube/glasskube/internal/controller/ctrlpkg"
 	"github.com/glasskube/glasskube/internal/manifestvalues/cli"
@@ -154,22 +155,22 @@ func printTransaction(tx update.UpdateTransaction) {
 	w := tabwriter.NewWriter(os.Stderr, 0, 0, 1, ' ', 0)
 	for _, item := range tx.Items {
 		if item.UpdateRequired() {
-			fmt.Fprintf(w, "%v\t%v:\t%v\t-> %v\n",
+			util.Must(fmt.Fprintf(w, "%v\t%v:\t%v\t-> %v\n",
 				item.Package.GetSpec().PackageInfo.Name,
 				cache.MetaObjectToName(item.Package),
 				item.Package.GetSpec().PackageInfo.Version,
 				item.Version,
-			)
+			))
 		} else {
-			fmt.Fprintf(w, "%v\t%v:\t%v\t(up-to-date)\n",
+			util.Must(fmt.Fprintf(w, "%v\t%v:\t%v\t(up-to-date)\n",
 				item.Package.GetSpec().PackageInfo.Name,
 				cache.MetaObjectToName(item.Package),
 				item.Package.GetSpec().PackageInfo.Version,
-			)
+			))
 		}
 	}
 	for _, req := range tx.Requirements {
-		fmt.Fprintf(w, "%v:\t-\t-> %v\n", req.Name, req.Version)
+		util.Must(fmt.Fprintf(w, "%v:\t-\t-> %v\n", req.Name, req.Version))
 	}
 	_ = w.Flush()
 }

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/glasskube/glasskube
 
-go 1.22.0
-
-toolchain go1.22.6
+go 1.23.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1

--- a/internal/cliutils/inputs.go
+++ b/internal/cliutils/inputs.go
@@ -47,7 +47,8 @@ func YesNoPrompt(label string, defaultChoice bool) bool {
 func GetInputStr(label string) (input string) {
 	fmt.Fprintf(os.Stderr, "%v> ", label)
 	InteractivityEnabledOrFail()
-	fmt.Scanln(&input)
+	// TODO: Handle the error returned by fmt.Scanln
+	_, _ = fmt.Scanln(&input)
 	return
 }
 

--- a/internal/cliutils/markdown.go
+++ b/internal/cliutils/markdown.go
@@ -69,7 +69,9 @@ func (*markdownRenderer) renderHeading(
 		bold.SetWriter(writer)
 	} else {
 		bold.UnsetWriter(writer)
-		fmt.Fprintln(writer)
+		if _, err := fmt.Fprintln(writer); err != nil {
+			return ast.WalkStop, err
+		}
 	}
 	return ast.WalkContinue, nil
 }
@@ -87,8 +89,12 @@ func (*markdownRenderer) renderBlockquote(
 func (r *markdownRenderer) renderCodeBlock(
 	writer util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
 	if entering {
-		r.writeLines(writer, source, n)
-		fmt.Fprintln(writer)
+		if err := r.writeLines(writer, source, n); err != nil {
+			return ast.WalkStop, err
+		}
+		if _, err := fmt.Fprintln(writer); err != nil {
+			return ast.WalkStop, err
+		}
 	}
 	return ast.WalkContinue, nil
 }
@@ -96,8 +102,12 @@ func (r *markdownRenderer) renderCodeBlock(
 func (r *markdownRenderer) renderFencedCodeBlock(
 	writer util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
 	if entering {
-		r.writeLines(writer, source, n)
-		fmt.Fprintln(writer)
+		if err := r.writeLines(writer, source, n); err != nil {
+			return ast.WalkStop, err
+		}
+		if _, err := fmt.Fprintln(writer); err != nil {
+			return ast.WalkStop, err
+		}
 	}
 	return ast.WalkContinue, nil
 }
@@ -115,7 +125,9 @@ func (r *markdownRenderer) renderList(
 		}
 	} else {
 		r.listContext = nil
-		fmt.Fprintln(writer)
+		if _, err := fmt.Fprintln(writer); err != nil {
+			return ast.WalkStop, err
+		}
 	}
 	return ast.WalkContinue, nil
 }
@@ -125,13 +137,19 @@ func (r *markdownRenderer) renderListItem(
 	n.Parent().(*ast.List).IsOrdered()
 	if entering {
 		if r.listContext.ordered {
-			fmt.Fprintf(writer, " %v) ", r.listContext.index+1)
+			if _, err := fmt.Fprintf(writer, " %v) ", r.listContext.index+1); err != nil {
+				return ast.WalkStop, err
+			}
 		} else {
-			fmt.Fprint(writer, " * ")
+			if _, err := fmt.Fprint(writer, " * "); err != nil {
+				return ast.WalkStop, err
+			}
 		}
 		r.listContext.index++
 	} else {
-		fmt.Fprintln(writer)
+		if _, err := fmt.Fprintln(writer); err != nil {
+			return ast.WalkStop, err
+		}
 	}
 	return ast.WalkContinue, nil
 }
@@ -139,7 +157,9 @@ func (r *markdownRenderer) renderListItem(
 func (*markdownRenderer) renderParagraph(
 	writer util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
 	if !entering {
-		fmt.Fprint(writer, "\n\n")
+		if _, err := fmt.Fprint(writer, "\n\n"); err != nil {
+			return ast.WalkStop, err
+		}
 	}
 	return ast.WalkContinue, nil
 }
@@ -148,7 +168,9 @@ func (*markdownRenderer) renderTextBlock(
 	writer util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
 	if !entering {
 		if n.NextSibling() != nil && n.FirstChild() != nil {
-			fmt.Fprintln(writer)
+			if _, err := fmt.Fprintln(writer); err != nil {
+				return ast.WalkStop, err
+			}
 		}
 	}
 	return ast.WalkContinue, nil
@@ -168,7 +190,9 @@ func (*markdownRenderer) renderThematicBreak(
 
 func (*markdownRenderer) renderAutoLink(
 	writer util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
-	fmt.Fprint(writer, n.Text(source))
+	if _, err := fmt.Fprint(writer, n.Text(source)); err != nil {
+		return ast.WalkStop, err
+	}
 	if entering {
 		underline.SetWriter(writer)
 	} else {
@@ -215,7 +239,9 @@ func (*markdownRenderer) renderLink(
 		if !strings.Contains(url, "://") {
 			url = "https://" + url
 		}
-		fmt.Fprintf(writer, " (%v)", underline.Sprint(url))
+		if _, err := fmt.Fprintf(writer, " (%v)", underline.Sprint(url)); err != nil {
+			return ast.WalkStop, err
+		}
 	}
 	return ast.WalkContinue, nil
 }
@@ -229,9 +255,13 @@ func (*markdownRenderer) renderText(
 	writer util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
 	if entering {
 		t := n.(*ast.Text)
-		_, _ = writer.Write(t.Segment.Value(source))
+		if _, err := writer.Write(t.Segment.Value(source)); err != nil {
+			return ast.WalkStop, err
+		}
 		if t.HardLineBreak() {
-			fmt.Fprintln(writer)
+			if _, err := fmt.Fprintln(writer); err != nil {
+				return ast.WalkStop, err
+			}
 		}
 		if t.SoftLineBreak() {
 			_, _ = writer.WriteRune(' ')
@@ -243,15 +273,20 @@ func (*markdownRenderer) renderText(
 func (*markdownRenderer) renderString(
 	writer util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	if entering {
-		_, _ = writer.Write(node.(*ast.String).Value)
+		if _, err := writer.Write(node.(*ast.String).Value); err != nil {
+			return ast.WalkStop, err
+		}
 	}
 	return ast.WalkContinue, nil
 }
 
-func (r *markdownRenderer) writeLines(w util.BufWriter, source []byte, n ast.Node) {
+func (r *markdownRenderer) writeLines(w util.BufWriter, source []byte, n ast.Node) error {
 	l := n.Lines().Len()
 	for i := 0; i < l; i++ {
 		line := n.Lines().At(i)
-		_, _ = w.Write(line.Value(source))
+		if _, err := w.Write(line.Value(source)); err != nil {
+			return err
+		}
 	}
+	return nil
 }

--- a/internal/cliutils/table.go
+++ b/internal/cliutils/table.go
@@ -16,7 +16,9 @@ func PrintTable[T any](
 	getColsOfRow func(item T) []string,
 ) error {
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tw, strings.Join(columns, tabSep))
+	if _, err := fmt.Fprintln(tw, strings.Join(columns, tabSep)); err != nil {
+		return err
+	}
 	var sb strings.Builder
 	for _, pkg := range rowItems {
 		colsOfRow := getColsOfRow(pkg)
@@ -27,7 +29,9 @@ func PrintTable[T any](
 			sb.WriteString(col)
 			sb.WriteString(tabSep)
 		}
-		fmt.Fprintln(tw, sb.String())
+		if _, err := fmt.Fprintln(tw, sb.String()); err != nil {
+			return err
+		}
 		sb.Reset()
 	}
 	return tw.Flush()

--- a/internal/dependency/graph/graph_test.go
+++ b/internal/dependency/graph/graph_test.go
@@ -43,7 +43,8 @@ var _ = Describe("DependencyGraph", func() {
 
 				When("there is a constraint and it is not violated", func() {
 					It("should not return an error", func() {
-						Expect(graph.AddCluster(foo, "v1.0.0", []v1alpha1.Dependency{{Name: bar, Version: "1.x.x"}}, true)).NotTo(HaveOccurred())
+						Expect(graph.AddCluster(foo, "v1.0.0", []v1alpha1.Dependency{{Name: bar, Version: "1.x.x"}}, true)).
+							NotTo(HaveOccurred())
 						Expect(graph.AddCluster(bar, "v1.0.0", nil, false)).NotTo(HaveOccurred())
 						Expect(graph.Validate()).NotTo(HaveOccurred())
 					})
@@ -51,9 +52,10 @@ var _ = Describe("DependencyGraph", func() {
 
 				When("there is a constraint and it is violated", func() {
 					It("should return an error", func() {
-						Expect(graph.AddCluster(foo, "v1.0.0", []v1alpha1.Dependency{{Name: bar, Version: "1.1.x"}}, true)).NotTo(HaveOccurred())
+						Expect(graph.AddCluster(foo, "v1.0.0", []v1alpha1.Dependency{{Name: bar, Version: "1.1.x"}}, true)).
+							NotTo(HaveOccurred())
 						Expect(graph.AddCluster(bar, "v1.0.0", nil, false)).NotTo(HaveOccurred())
-						Expect(graph.Validate()).To(MatchError(&DependencyError{}))
+						Expect(graph.Validate()).To(MatchError((error)(&DependencyError{})))
 					})
 				})
 			})
@@ -61,7 +63,7 @@ var _ = Describe("DependencyGraph", func() {
 			When("the dependency does not exist", func() {
 				It("should return an error", func() {
 					Expect(graph.AddCluster(foo, "v1.0.0", []v1alpha1.Dependency{{Name: bar}}, true)).NotTo(HaveOccurred())
-					Expect(graph.Validate()).To(MatchError(&DependencyError{}))
+					Expect(graph.Validate()).To(MatchError((error)(&DependencyError{})))
 				})
 			})
 		})
@@ -78,7 +80,8 @@ var _ = Describe("DependencyGraph", func() {
 
 				When("there is a constraint and it is not violated", func() {
 					It("should not return an error", func() {
-						Expect(graph.AddNamespaced(foo, foo, "v1.0.0", []v1alpha1.Dependency{{Name: bar, Version: "1.x.x"}})).NotTo(HaveOccurred())
+						Expect(graph.AddNamespaced(foo, foo, "v1.0.0", []v1alpha1.Dependency{{Name: bar, Version: "1.x.x"}})).
+							NotTo(HaveOccurred())
 						Expect(graph.AddCluster(bar, "v1.0.0", nil, false)).NotTo(HaveOccurred())
 						Expect(graph.Validate()).NotTo(HaveOccurred())
 					})
@@ -86,9 +89,10 @@ var _ = Describe("DependencyGraph", func() {
 
 				When("there is a constraint and it is violated", func() {
 					It("should return an error", func() {
-						Expect(graph.AddNamespaced(foo, foo, "v1.0.0", []v1alpha1.Dependency{{Name: bar, Version: "1.1.x"}})).NotTo(HaveOccurred())
+						Expect(graph.AddNamespaced(foo, foo, "v1.0.0", []v1alpha1.Dependency{{Name: bar, Version: "1.1.x"}})).
+							NotTo(HaveOccurred())
 						Expect(graph.AddCluster(bar, "v1.0.0", nil, false)).NotTo(HaveOccurred())
-						Expect(graph.Validate()).To(MatchError(&DependencyError{}))
+						Expect(graph.Validate()).To(MatchError((error)(&DependencyError{})))
 					})
 				})
 			})
@@ -96,7 +100,7 @@ var _ = Describe("DependencyGraph", func() {
 			When("the dependency does not exist", func() {
 				It("should return an error", func() {
 					Expect(graph.AddNamespaced(foo, foo, "v1.0.0", []v1alpha1.Dependency{{Name: bar}})).NotTo(HaveOccurred())
-					Expect(graph.Validate()).To(MatchError(&DependencyError{}))
+					Expect(graph.Validate()).To(MatchError((error)(&DependencyError{})))
 				})
 			})
 		})
@@ -138,7 +142,8 @@ var _ = Describe("DependencyGraph", func() {
 		It("should return error for empty slice", func() {
 			Expect(graph.AddCluster(foo, "v1.0.0", []v1alpha1.Dependency{{Name: bar, Version: ">= 1.0.0, < 1.1.2"}}, true)).
 				NotTo(HaveOccurred())
-			Expect(graph.AddCluster(baz, "v1.0.0", []v1alpha1.Dependency{{Name: bar, Version: ">= 1.1.0"}}, true)).NotTo(HaveOccurred())
+			Expect(graph.AddCluster(baz, "v1.0.0", []v1alpha1.Dependency{{Name: bar, Version: ">= 1.1.0"}}, true)).
+				NotTo(HaveOccurred())
 			v, err := graph.Max(bar, []*semver.Version{})
 			Expect(err).To(HaveOccurred())
 			Expect(v).To(BeNil())
@@ -147,7 +152,8 @@ var _ = Describe("DependencyGraph", func() {
 		It("should return error for no matching version", func() {
 			Expect(graph.AddCluster(foo, "v1.0.0", []v1alpha1.Dependency{{Name: bar, Version: ">= 1.0.0, < 1.1.1"}}, true)).
 				NotTo(HaveOccurred())
-			Expect(graph.AddCluster(baz, "v1.0.0", []v1alpha1.Dependency{{Name: bar, Version: ">= 1.1.0"}}, true)).NotTo(HaveOccurred())
+			Expect(graph.AddCluster(baz, "v1.0.0", []v1alpha1.Dependency{{Name: bar, Version: ">= 1.1.0"}}, true)).
+				NotTo(HaveOccurred())
 			versions := []*semver.Version{semver.MustParse("1.0.0"), semver.MustParse("1.1.1"), semver.MustParse("1.2.0"),
 				semver.MustParse("2.0.0")}
 			v, err := graph.Max(bar, versions)
@@ -178,8 +184,10 @@ var _ = Describe("DependencyGraph", func() {
 
 	Describe("Dependants", func() {
 		It("should return all dependants", func() {
-			Expect(graph.AddNamespaced(foo, foo, "v1.0.0", []v1alpha1.Dependency{{Name: bar, Version: "1.x.x"}})).NotTo(HaveOccurred())
-			Expect(graph.AddCluster(foo, "v1.0.0", []v1alpha1.Dependency{{Name: bar, Version: "1.x.x"}}, true)).NotTo(HaveOccurred())
+			Expect(graph.AddNamespaced(foo, foo, "v1.0.0", []v1alpha1.Dependency{{Name: bar, Version: "1.x.x"}})).
+				NotTo(HaveOccurred())
+			Expect(graph.AddCluster(foo, "v1.0.0", []v1alpha1.Dependency{{Name: bar, Version: "1.x.x"}}, true)).
+				NotTo(HaveOccurred())
 			Expect(graph.AddCluster(baz, "v1.0.0", []v1alpha1.Dependency{{Name: bar}}, true)).NotTo(HaveOccurred())
 			Expect(graph.AddCluster(bar, "v1.0.0", nil, false)).NotTo(HaveOccurred())
 			Expect(graph.Dependants(bar)).To(ContainElements(foo, baz))
@@ -189,8 +197,10 @@ var _ = Describe("DependencyGraph", func() {
 
 	Describe("Constraints", func() {
 		It("should return constraints of dependants", func() {
-			Expect(graph.AddNamespaced(foo, foo, "v1.0.0", []v1alpha1.Dependency{{Name: bar, Version: "1.2.x"}})).NotTo(HaveOccurred())
-			Expect(graph.AddCluster(foo, "v1.0.0", []v1alpha1.Dependency{{Name: bar, Version: "1.x.x"}}, true)).NotTo(HaveOccurred())
+			Expect(graph.AddNamespaced(foo, foo, "v1.0.0", []v1alpha1.Dependency{{Name: bar, Version: "1.2.x"}})).
+				NotTo(HaveOccurred())
+			Expect(graph.AddCluster(foo, "v1.0.0", []v1alpha1.Dependency{{Name: bar, Version: "1.x.x"}}, true)).
+				NotTo(HaveOccurred())
 			Expect(graph.AddCluster(baz, "v1.0.0", []v1alpha1.Dependency{{Name: bar}}, true)).NotTo(HaveOccurred())
 			Expect(graph.AddCluster(bar, "v1.0.0", nil, false)).NotTo(HaveOccurred())
 			Expect(graph.Constraints(bar)).To(ConsistOf(constraint("1.x.x"), constraint("1.2.x")))
@@ -199,7 +209,8 @@ var _ = Describe("DependencyGraph", func() {
 
 	Describe("DeepCopy", func() {
 		It("should produce equal graph", func() {
-			Expect(graph.AddCluster(foo, "v1.0.0", []v1alpha1.Dependency{{Name: bar, Version: "1.x.x"}}, true)).NotTo(HaveOccurred())
+			Expect(graph.AddCluster(foo, "v1.0.0", []v1alpha1.Dependency{{Name: bar, Version: "1.x.x"}}, true)).
+				NotTo(HaveOccurred())
 			Expect(graph.AddCluster(bar, "v1.0.0", nil, false)).NotTo(HaveOccurred())
 			newGraph := graph.DeepCopy()
 			Expect(graph.AddCluster(bar, "v1.1.0", nil, false)).NotTo(HaveOccurred())

--- a/internal/semver/validate_test.go
+++ b/internal/semver/validate_test.go
@@ -13,7 +13,7 @@ var _ = Describe("ValidateConstraint", func() {
 				Expect(err).NotTo(HaveOccurred())
 			} else {
 				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError((*ConstraintValidationError)(nil)))
+				Expect(err).To(MatchError((error)(&ConstraintValidationError{})))
 			}
 		},
 		Entry("When minor version is pinned", ">=1.2.0 <1.3.0", "1.2.0", true),

--- a/pkg/statuswriter/writer.go
+++ b/pkg/statuswriter/writer.go
@@ -13,7 +13,8 @@ type writerStatusWriter struct {
 
 // SetStatus implements StatusWriter.
 func (obj *writerStatusWriter) SetStatus(desc string) {
-	fmt.Fprintln(obj.writer, desc)
+	// TODO: Handle error returned by fmt.Fprintln
+	_, _ = fmt.Fprintln(obj.writer, desc)
 }
 
 // Start implements StatusWriter.


### PR DESCRIPTION
## 📑 Description
This PR bumps the Go version to 1.23 across the entire project. golangci-lint is updated to 1.60.1 because older versions are not compatible with Go 1.23.

Additionally, this PR contains some changes that fix lint errors that were uncovered due to additional checks in this new version of golangci-lint.


## ℹ Additional Information
Release notes: 
- Go: https://go.dev/doc/go1.23
- golangci-lint: https://github.com/golangci/golangci-lint/releases/tag/v1.60.1