### PR TITLE
feat(package-operator): add handling of local path manifest url

### DIFF
--- a/api/v1alpha1/package_manifest.go
+++ b/api/v1alpha1/package_manifest.go
@@ -57,6 +57,10 @@ type PackageEntrypoint struct {
 }
 
 type PlainManifest struct {
+	// Url is the location of the manifest.
+	// Typically, this should be a full https URL, but local paths are also supporeted.
+	// If this field is set to a local path (e.g. a relative path like "./manifest.yaml" or just "manifest.yaml") it
+	// will be resolved relative to the packages "package.yaml" file.
 	Url string `json:"url" jsonschema:"required"`
 	// DefaultNamespace, if set to a non-empty string, is used for resources that are of a namespaced
 	// kind and do not have a namespace set.

--- a/api/v1alpha1/packageinfo_types.go
+++ b/api/v1alpha1/packageinfo_types.go
@@ -34,6 +34,7 @@ type PackageInfoSpec struct {
 // PackageInfoStatus defines the observed state of PackageInfo
 type PackageInfoStatus struct {
 	Manifest            *PackageManifest   `json:"manifest,omitempty"`
+	ResolvedUrl         string             `json:"resolvedUrl,omitempty"`
 	Conditions          []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 	LastUpdateTimestamp *metav1.Time       `json:"lastUpdateTimestamp,omitempty"`
 	Version             string             `json:"version,omitempty"`

--- a/config/crd/bases/packages.glasskube.dev_packageinfos.yaml
+++ b/config/crd/bases/packages.glasskube.dev_packageinfos.yaml
@@ -222,6 +222,11 @@ spec:
                             If at least one such a resource exists, the namespace is created implicitly.
                           type: string
                         url:
+                          description: |-
+                            Url is the location of the manifest.
+                            Typically, this should be a full https URL, but local paths are also supporeted.
+                            If this field is set to a local path (e.g. a relative path like "./manifest.yaml" or just "manifest.yaml") it
+                            will be resolved relative to the packages "package.yaml" file.
                           type: string
                       required:
                       - url
@@ -350,6 +355,8 @@ spec:
                 required:
                 - name
                 type: object
+              resolvedUrl:
+                type: string
               version:
                 type: string
             type: object

--- a/internal/controller/common.go
+++ b/internal/controller/common.go
@@ -207,7 +207,7 @@ func (r *PackageReconcilationContext) reconcilePackageInfoReady(ctx context.Cont
 	results := make([]result.ReconcileResult, 0, len(adaptersToRun))
 	var errs error
 	for _, adapter := range adaptersToRun {
-		if result, err := adapter.Reconcile(ctx, r.pkg, piManifest, patches); err != nil {
+		if result, err := adapter.Reconcile(ctx, r.pkg, r.pi, patches); err != nil {
 			errs = multierr.Append(errs, err)
 		} else {
 			results = append(results, *result)

--- a/internal/manifest/adapter.go
+++ b/internal/manifest/adapter.go
@@ -3,7 +3,7 @@ package manifest
 import (
 	"context"
 
-	packagesv1alpha1 "github.com/glasskube/glasskube/api/v1alpha1"
+	"github.com/glasskube/glasskube/api/v1alpha1"
 	"github.com/glasskube/glasskube/internal/controller/ctrlpkg"
 	"github.com/glasskube/glasskube/internal/manifest/result"
 	"github.com/glasskube/glasskube/internal/manifestvalues"
@@ -16,7 +16,7 @@ type ManifestAdapter interface {
 	ControllerInit(builder *builder.Builder, client client.Client, scheme *runtime.Scheme) error
 	Reconcile(ctx context.Context,
 		pkg ctrlpkg.Package,
-		manifest *packagesv1alpha1.PackageManifest,
+		pi *v1alpha1.PackageInfo,
 		patches manifestvalues.TargetPatches,
 	) (*result.ReconcileResult, error)
 }

--- a/internal/manifest/helm/flux/adapter.go
+++ b/internal/manifest/helm/flux/adapter.go
@@ -58,9 +58,10 @@ func (a *FluxHelmAdapter) ControllerInit(buildr *builder.Builder, client client.
 func (a *FluxHelmAdapter) Reconcile(
 	ctx context.Context,
 	pkg ctrlpkg.Package,
-	manifest *packagesv1alpha1.PackageManifest,
+	pi *packagesv1alpha1.PackageInfo,
 	patches manifestvalues.TargetPatches,
 ) (*result.ReconcileResult, error) {
+	manifest := pi.Status.Manifest
 	log := ctrl.LoggerFrom(ctx)
 	var ownedResources []packagesv1alpha1.OwnedResourceRef
 	if !pkg.IsNamespaceScoped() {

--- a/internal/manifest/plain/adapter_test.go
+++ b/internal/manifest/plain/adapter_test.go
@@ -1,0 +1,50 @@
+package plain
+
+import (
+	"github.com/glasskube/glasskube/api/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("getActualManifestUrl", func() {
+	It("should handle relative url", func() {
+		result, err := getActualManifestUrl(
+			&v1alpha1.PackageInfo{Status: v1alpha1.PackageInfoStatus{ResolvedUrl: "http://localhost/packages/foo/package.yaml"}},
+			"./manifest.yaml",
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal("http://localhost/packages/foo/manifest.yaml"))
+	})
+	It("should handle plain file name", func() {
+		result, err := getActualManifestUrl(
+			&v1alpha1.PackageInfo{Status: v1alpha1.PackageInfoStatus{ResolvedUrl: "http://localhost/packages/foo/package.yaml"}},
+			"manifest.yaml",
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal("http://localhost/packages/foo/manifest.yaml"))
+	})
+	It("should handle relative url with \"..\"", func() {
+		result, err := getActualManifestUrl(
+			&v1alpha1.PackageInfo{Status: v1alpha1.PackageInfoStatus{ResolvedUrl: "http://localhost/packages/foo/package.yaml"}},
+			"../manifest.yaml",
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal("http://localhost/packages/manifest.yaml"))
+	})
+	It("should handle absolute path", func() {
+		result, err := getActualManifestUrl(
+			&v1alpha1.PackageInfo{Status: v1alpha1.PackageInfoStatus{ResolvedUrl: "http://localhost/packages/foo/package.yaml"}},
+			"/manifest.yaml",
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal("http://localhost/manifest.yaml"))
+	})
+	It("should handle real url", func() {
+		result, err := getActualManifestUrl(
+			&v1alpha1.PackageInfo{Status: v1alpha1.PackageInfoStatus{ResolvedUrl: "http://localhost/packages/foo/package.yaml"}},
+			"https://github.com/glasskube/glasskube/manifest.yaml",
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal("https://github.com/glasskube/glasskube/manifest.yaml"))
+	})
+})

--- a/internal/manifest/plain/suite_test.go
+++ b/internal/manifest/plain/suite_test.go
@@ -1,0 +1,13 @@
+package plain
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestPlainManifestAdapter(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "PlainManifestAdapter Suite")
+}


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #1085  <!-- Issue # here -->

## 📑 Description
This PR adds handling of local path manifest URLs in package manifests. In order to ensure that the operator always uses the correct base URL, the resolved URL of the package.yaml is stored in the PackageInfo status and all local paths are resolved relative to that.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->