### PR TITLE
chore: add name field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "glasskube",
   "author": "Glasskube",
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
The npm spec requires name (and version) fields. I did this because I ran into build difficulties due to its omission.

<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
Just added a 'name' property, [as demanded by the npm spec](https://docs.npmjs.com/creating-a-package-json-file#required-name-and-version-fields).

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required