### PR TITLE
docs(website): correct install command for Alpine Linux

### DIFF
--- a/website/src/partials/_install.mdx
+++ b/website/src/partials/_install.mdx
@@ -36,7 +36,7 @@ import TabItem from '@theme/TabItem';
       {/* x-release-please-start-version */}
       ```
       curl -LO https://releases.dl.glasskube.dev/glasskube_v0.17.0_amd64.apk
-      apk add glasskube.apk
+      apk add --allow-untrusted glasskube_v0.17.0_amd64.apk
       ```
       {/* x-release-please-end */}
     </details>


### PR DESCRIPTION
## 📑 Description

In the [Installation Guide](https://glasskube.dev/docs/getting-started/install/), the instructions for Alpine Linux contain 2 mistakes:

 - the filename of the package is incorrect
 - the package is untrusted by Alpine, therefore the `--allow-untrusted` option is missing

Thus, simply copy/pasting the commands will result in an error (even though it is easy to overcome).

## ✅ Checks
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required

## ℹ Additional Information

N/A