### PR TITLE
fix(package-operator): package repository webhook validation

### DIFF
--- a/internal/webhook/packagerepository_webhook.go
+++ b/internal/webhook/packagerepository_webhook.go
@@ -61,6 +61,8 @@ func (p *PackageRepositoryValidatingWebhook) ValidateUpdate(ctx context.Context,
 			log.Info("validate update", "name", newRepo.Name)
 			if oldRepo.Spec.Url != newRepo.Spec.Url {
 				return nil, p.validateUpdateOrDelete(ctx, oldRepo)
+			} else {
+				return nil, nil
 			}
 		}
 	}

--- a/internal/webhook/packagerepository_webhook_test.go
+++ b/internal/webhook/packagerepository_webhook_test.go
@@ -102,5 +102,12 @@ var _ = Describe("PackageRepositoryValidatingWebhook", Ordered, func() {
 				Expect(err).To(MatchError(ErrPackagesInstalled))
 			})
 		})
+		When("url not changed", func() {
+			It("should not return an error", func(ctx context.Context) {
+				webhook := newPackageRepositoryValidatingWebhook(&glasskubev1Repo, &hinterseerv1Package, &hinterseerv1PackageInfo)
+				_, err := webhook.ValidateUpdate(ctx, &glasskubev1Repo, &glasskubev1Repo)
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
 	})
 })


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #1155

## 📑 Description
This should at least fix one part of the #1155 issue. Problem was that it was not allowed to update a package repository if the URL did not change, due to a missing else branch.

I don't know about the first part of the issue though (certificate error – pretty sure that only happens during the update of an installation, and maybe the cert-manager generates a new cert there and it's just not ready in time?). 

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->