### PR TITLE
Use default namespace when --yes is specified 

### DIFF
--- a/cmd/glasskube/cmd/install.go
+++ b/cmd/glasskube/cmd/install.go
@@ -147,10 +147,14 @@ var installCmd = &cobra.Command{
 		} else {
 			var name string
 			if len(args) != 2 {
-				fmt.Fprintf(os.Stderr, "%v has scope Namespaced. Please enter a name (default %v):\n", packageName, packageName)
-				name = cliutils.GetInputStr("name")
-				if name == "" {
+				if installCmdOptions.Yes {
 					name = packageName
+				} else {
+					fmt.Fprintf(os.Stderr, "%v has scope Namespaced. Please enter a name (default %v):\n", packageName, packageName)
+					name = cliutils.GetInputStr("name")
+					if name == "" {
+						name = packageName
+					}
 				}
 			} else {
 				name = args[1]


### PR DESCRIPTION
Closes #1163

## 📑 Description
Using the default namespace when the --yes flag is specified with the `glasskube install` command.
If `installCmdOptions.Yes` is set the default namespace is used.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required