### PR TITLE
feat(cli): add markdown support for value descriptions when configuring a package via CLI

### DIFF
--- a/internal/manifestvalues/cli/configure.go
+++ b/internal/manifestvalues/cli/configure.go
@@ -151,7 +151,7 @@ func printMarkdown(w io.Writer, text string) {
 	if err := md.Convert([]byte(text), &buf); err != nil {
 		util.Must(fmt.Fprintln(w, text))
 	} else {
-		util.Must(fmt.Fprintln(w, strings.TrimSpace(buf.String())))
+		util.Must(fmt.Fprint(w, strings.TrimSpace(buf.String())+"\n\n"))
 	}
 }
 


### PR DESCRIPTION
Closes #1022

## 📑 Description
Adds Markdown rendering support to the glasskube configure command, aligning it with the existing functionality in the describe command.

## Changes
- Created `PrintMarkdown` utility in `internal/manifestvalues/cli/configure.go`

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required