### PR TITLE
fix(build): fix completions

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -170,9 +170,6 @@ brews:
     commit_msg_template: "chore: brew formula update for {{ .ProjectName }} version {{ .Tag }}"
     install: |
       bin.install "glasskube"
-      bash_completion.install "completions/glasskube.bash" => "glasskube"
-      zsh_completion.install "completions/glasskube.zsh" => "_glasskube"
-      fish_completion.install "completions/glasskube.fish"
     skip_upload: "auto"
 
 release:


### PR DESCRIPTION

## 📑 Description
Completions introduced in https://github.com/glasskube/glasskube/pull/1192 fail due to the projects like https://github.com/go-task/task have a completions folder which they just copy into the local home directory.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->