### PR TITLE
feat: generate completions after brew install

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -170,6 +170,8 @@ brews:
     commit_msg_template: "chore: brew formula update for {{ .ProjectName }} version {{ .Tag }}"
     install: |
       bin.install "glasskube"
+    post_install: |
+      generate_completions_from_executable(bin/"glasskube", "completions")
     skip_upload: "auto"
 
 release:


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Resolves issue with Completions introduced in https://github.com/glasskube/glasskube/pull/1192

## 📑 Description
Removes three install lines from previous commit and uses homebrew function in post_install block to generate and install the completions
[Class: Formula      — Homebrew Ruby API](https://rubydoc.brew.sh/Formula.html#generate_completions_from_executable-instance_method)

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
