### PR TITLE
fix(ui): use hardcoded giscus backlink

### DIFF
--- a/internal/web/templates/layout/base.html
+++ b/internal/web/templates/layout/base.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="giscus:backlink" content="https://glasskube.dev/packages" />
     <title>Glasskube</title>
     <link type="text/css" rel="stylesheet" href="/static/bundle/index.min.css?v={{ .CacheBustingString }}" />
     <script src="/static/bundle/index.min.js?v={{ .CacheBustingString }}"></script>


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->

## 📑 Description
The Giscus backlink is put into the github discussion content. 
A link to 127.0.0.1 doesn't make a lot of sense to anyone who doesn't have glasskube installed or not running right now, or running on a different host / port. So I changed the backlink to our public packages page on the website (discussable if useful, but leaving it empty does not seem to be an option). 

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
Giscus Docs https://github.com/giscus/giscus/blob/main/ADVANCED-USAGE.md#giscusbacklink