### PR TITLE
fix: consider metadata when calculating max version

### DIFF
--- a/internal/dependency/graph/graph.go
+++ b/internal/dependency/graph/graph.go
@@ -155,12 +155,13 @@ func (g *DependencyGraph) Constraints(of, namespace string) []*semver.Constraint
 	return constraints
 }
 
-// Max returns the maximum element of versions that does not violate any constraint of this package
+// Max returns the maximum element of versions that does not violate any constraint of this package. Note that it
+// also interprets the metadata of the versions, just as in IsVersionUpgradable.
 func (g *DependencyGraph) Max(of, namespace string, versions []*semver.Version) (*semver.Version, error) {
 	var maxVersion *semver.Version
 outer:
 	for _, version := range versions {
-		if maxVersion == nil || maxVersion.LessThan(version) {
+		if maxVersion == nil || isemver.IsVersionUpgradable(maxVersion, version) {
 			for _, constraint := range g.Constraints(of, namespace) {
 				if isemver.ValidateVersionConstraint(version, constraint) != nil {
 					continue outer


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->

## 📑 Description
When two version numbers of a package only differ in the metadata, we did not deterministically calculate which version to choose. We now also try to interpret the metadata. We still do not consider the metadata in constraints though, as by design. 

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->