### PR TITLE
Add text-break to contain the text inside the toast-body

### DIFF
--- a/internal/web/templates/components/toast.html
+++ b/internal/web/templates/components/toast.html
@@ -2,7 +2,7 @@
   <div class="toast text-bg-{{ .CssClass }} border-0 show" role="alert" aria-live="assertive" aria-atomic="true">
     <div class="d-flex">
       <div class="toast-body">
-        <strong>{{ .Message }}</strong>
+        <strong class="text-break">{{ .Message }}</strong>
       </div>
       {{ if .Dismissible }}
         <button


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #1277 

## 📑 Description
Add text-break to contain the text inside the toast-body 

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
![msedge_1QPHUjLvAP](https://github.com/user-attachments/assets/7f0a575c-7e75-434d-836c-5c58a727ca01)
