### PR TITLE
docs(website): fix link to package configuration design documentation in guides

### DIFF
--- a/website/guides/08_package-creation.mdx
+++ b/website/guides/08_package-creation.mdx
@@ -157,7 +157,7 @@ manifests:
 ```
 
 #### 4\. Value Definitions (Optional)
-Link to the official package config [documentation](https://github.com/glasskube/glasskube/blob/main/website/docs/04_design/package-config.md)
+Link to the official package config [documentation](https://github.com/glasskube/glasskube/blob/main/website/docs/05_design/package-config.md)
 
 Use the valueDefinitions section for interactive package configuration. This allows users to input values that modify the package configuration.
 

--- a/website/guides/08_package-creation.mdx
+++ b/website/guides/08_package-creation.mdx
@@ -80,7 +80,7 @@ Glasskube consists of distinct `client-side` and `server-side` components:
 ![argo-workflow-gif](https://github.com/user-attachments/assets/07123727-9b02-4946-9e98-9feead827f3b)
 
 ## Package repository structure 🏗️
-Link to more in depth repository structure [documentation](https://github.com/glasskube/glasskube/blob/main/website/docs/04_design/repositories.mdx)
+Link to more in depth repository structure [documentation](/docs/design/repositories)
 
 ![package-repo-structure](https://github.com/user-attachments/assets/67b6d5d5-f8da-4a84-8be9-1ec852ae4507)
 
@@ -157,7 +157,7 @@ manifests:
 ```
 
 #### 4\. Value Definitions (Optional)
-Link to the official package config [documentation](https://github.com/glasskube/glasskube/blob/main/website/docs/05_design/package-config.md)
+Link to the official package config [documentation](/docs/design/package-config)
 
 Use the valueDefinitions section for interactive package configuration. This allows users to input values that modify the package configuration.
 


### PR DESCRIPTION
## 📑 Description

Guide "How to add a Package to Glasskube" contained a link to the design document "Package Configuration". The link was `04_design/package-config.md` but since then, the folder has been renamed `05_design/package-config.md`.

## ✅ Checks
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->