### PR TITLE
fix(ui): clear previous modal content

### DIFF
--- a/web/custom.js
+++ b/web/custom.js
@@ -23,6 +23,15 @@
     });
 })();
 
+(() => {
+  const modal = document.getElementById('modal-container');
+  modal.addEventListener('show.bs.modal', (evt) => {
+    // https://getbootstrap.com/docs/5.3/components/modal/#events
+    // "hidden.bs.modal" is too early to clear innerHTML – the form submission from inside the modal would be cancelled
+    modal.innerHTML = '';
+  });
+})();
+
 function setSSEDisconnected() {
   const elem = document.getElementById('disconnected-toast');
   if (elem && !elem.classList.contains('show')) {


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->

## 📑 Description
When opening a modal, the previous content is still there until it is swapped out. Sometimes on slow requests, that can be confusing. When the new modal request errors, there might be a toast shown but also the previous content is still there. This would be a hack to avoid that confusion. 

Use cases where this might occur: installing a namespaced package in gitops mode, using a namespace that does not exist yet. The dry-run installation will throw an error because of that, but the modal will still be shown with the previous content. 

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->