### PR TITLE
fix(package-operator): add auth support for relative manifest urls in package.yaml

### DIFF
--- a/cmd/glasskube/cmd/bootstrap_git.go
+++ b/cmd/glasskube/cmd/bootstrap_git.go
@@ -119,7 +119,7 @@ var bootstrapGitCmd = &cobra.Command{
 		argocdPath := baseURL.JoinPath("packages", "argo-cd", "clusterpackage.yaml").String()
 		argocdVersion := "v2.11.7+1"
 		argocdRepo := "glasskube"
-		if objs, err := clientutils.FetchResources(argocdPath); err != nil {
+		if objs, err := clientutils.FetchResourcesFromUrl(argocdPath); err != nil {
 			fmt.Fprintf(os.Stderr, "\nAn error occurred fetching argo-cd clusterpackage "+
 				"(will use %v from repo %v instead): %v\n", argocdVersion, argocdRepo, err)
 		} else if len(objs) != 1 {
@@ -184,7 +184,7 @@ var bootstrapGitCmd = &cobra.Command{
 		// apply bootstrap/glasskube-application.yaml into the cluster
 		// appPath := fmt.Sprintf("%v/bootstrap/glasskube-application.yaml", baseURL.String())
 		appPath := baseURL.JoinPath("bootstrap", "glasskube-application.yaml").String()
-		if objs, err := clientutils.FetchResources(appPath); err != nil {
+		if objs, err := clientutils.FetchResourcesFromUrl(appPath); err != nil {
 			fmt.Fprintf(os.Stderr, "\nAn error occurred fetching the bootstrap application:\n%v\n", err)
 			cliutils.ExitWithError()
 		} else {

--- a/internal/clientutils/resources.go
+++ b/internal/clientutils/resources.go
@@ -11,13 +11,26 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
-func FetchResources(url string) ([]unstructured.Unstructured, error) {
+func FetchResourcesFromUrl(url string) ([]unstructured.Unstructured, error) {
+	if request, err := NewResourcesRequest(url); err != nil {
+		return nil, err
+	} else {
+		return FetchResources(request)
+	}
+}
+
+func NewResourcesRequest(url string) (*http.Request, error) {
 	request, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
 	request.Header.Add("Accept", contenttype.MediaTypeJSON)
 	request.Header.Add("Accept", contenttype.MediaTypeYAML)
+	return request, nil
+}
+
+func FetchResources(request *http.Request) ([]unstructured.Unstructured, error) {
+	url := request.URL.Redacted()
 	response, err := httperror.CheckResponse(http.DefaultClient.Do(request))
 	if err != nil {
 		switch {

--- a/internal/controller/common.go
+++ b/internal/controller/common.go
@@ -92,7 +92,7 @@ func (r *PackageReconcilerCommon) baseSetup(
 func (r *PackageReconcilerCommon) InitAdapters(builder *builder.Builder) error {
 	for _, adapter := range []manifest.ManifestAdapter{r.HelmAdapter, r.KustomizeAdapter, r.ManifestAdapter} {
 		if adapter != nil {
-			if err := adapter.ControllerInit(builder, r.Client, r.Scheme); err != nil {
+			if err := adapter.ControllerInit(builder, r.Client, r.RepoClientset, r.Scheme); err != nil {
 				return err
 			}
 		}

--- a/internal/dependency/manager_test.go
+++ b/internal/dependency/manager_test.go
@@ -14,11 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-var fakeRepo = &fake.FakeClient{
-	PackageRepositories: []v1alpha1.PackageRepository{
-		{},
-	},
-}
+var fakeRepo = fake.EmptyClient()
 
 type testClientAdapter struct {
 	clusterPackages []v1alpha1.ClusterPackage
@@ -66,7 +62,7 @@ func (a *testClientAdapter) ListPackageRepositories(ctx context.Context) (*v1alp
 
 func createDependencyManager() *DependendcyManager {
 	testClient = &testClientAdapter{}
-	return NewDependencyManager(testClient, &fake.FakeClientset{Client: fakeRepo})
+	return NewDependencyManager(testClient, fake.ClientsetWithClient(fakeRepo))
 }
 
 var testClient *testClientAdapter

--- a/internal/manifest/adapter.go
+++ b/internal/manifest/adapter.go
@@ -6,6 +6,7 @@ import (
 	"github.com/glasskube/glasskube/api/v1alpha1"
 	"github.com/glasskube/glasskube/internal/controller/ctrlpkg"
 	"github.com/glasskube/glasskube/internal/manifest/result"
+	repoclient "github.com/glasskube/glasskube/internal/repo/client"
 	"github.com/glasskube/glasskube/internal/resourcepatch"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -13,8 +14,14 @@ import (
 )
 
 type ManifestAdapter interface {
-	ControllerInit(builder *builder.Builder, client client.Client, scheme *runtime.Scheme) error
-	Reconcile(ctx context.Context,
+	ControllerInit(
+		builder *builder.Builder,
+		client client.Client,
+		repo repoclient.RepoClientset,
+		scheme *runtime.Scheme,
+	) error
+	Reconcile(
+		ctx context.Context,
 		pkg ctrlpkg.Package,
 		pi *v1alpha1.PackageInfo,
 		patches resourcepatch.TargetPatches,

--- a/internal/manifest/helm/flux/adapter.go
+++ b/internal/manifest/helm/flux/adapter.go
@@ -16,6 +16,7 @@ import (
 	"github.com/glasskube/glasskube/internal/manifest"
 	"github.com/glasskube/glasskube/internal/manifest/result"
 	"github.com/glasskube/glasskube/internal/names"
+	repoclient "github.com/glasskube/glasskube/internal/repo/client"
 	"github.com/glasskube/glasskube/internal/resourcepatch"
 	corev1 "k8s.io/api/core/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -38,7 +39,12 @@ func NewAdapter() manifest.ManifestAdapter {
 	return &FluxHelmAdapter{}
 }
 
-func (a *FluxHelmAdapter) ControllerInit(buildr *builder.Builder, client client.Client, scheme *runtime.Scheme) error {
+func (a *FluxHelmAdapter) ControllerInit(
+	buildr *builder.Builder,
+	client client.Client,
+	repo repoclient.RepoClientset,
+	scheme *runtime.Scheme,
+) error {
 	if err := sourcev1.AddToScheme(scheme); err != nil {
 		return err
 	}

--- a/internal/manifest/plain/url.go
+++ b/internal/manifest/plain/url.go
@@ -1,23 +1,28 @@
 package plain
 
 import (
+	"net/http"
 	"net/url"
 
 	packagesv1alpha1 "github.com/glasskube/glasskube/api/v1alpha1"
+	"github.com/glasskube/glasskube/internal/clientutils"
 )
 
-func getActualManifestUrl(pi *packagesv1alpha1.PackageInfo, urlOrPath string) (string, error) {
+func (r *Adapter) newManifestRequest(pi *packagesv1alpha1.PackageInfo, urlOrPath string) (*http.Request, error) {
 	if parsedUrl, err := url.Parse(urlOrPath); err != nil {
-		return "", err
+		return nil, err
 	} else if parsedUrl.Scheme == "" && parsedUrl.Host == "" {
 		if parsedBase, err := url.Parse(pi.Status.ResolvedUrl); err != nil {
-			return "", err
+			return nil, err
 		} else if ref, err := parsedBase.Parse(urlOrPath); err != nil {
-			return "", err
+			return nil, err
+		} else if request, err := clientutils.NewResourcesRequest(ref.String()); err != nil {
+			return nil, err
 		} else {
-			return ref.String(), nil
+			r.repo.ForRepoWithName(pi.Spec.RepositoryName).Authenticate(request)
+			return request, nil
 		}
 	} else {
-		return urlOrPath, nil
+		return clientutils.NewResourcesRequest(urlOrPath)
 	}
 }

--- a/internal/manifest/plain/url_test.go
+++ b/internal/manifest/plain/url_test.go
@@ -2,49 +2,89 @@ package plain
 
 import (
 	"github.com/glasskube/glasskube/api/v1alpha1"
+	"github.com/glasskube/glasskube/internal/repo/client/auth"
+	"github.com/glasskube/glasskube/internal/repo/client/fake"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
+var adapter = &Adapter{}
+
 var _ = Describe("getActualManifestUrl", func() {
+	BeforeEach(func() {
+		adapter.repo = fake.EmptyClientset()
+	})
+
 	It("should handle relative url", func() {
-		result, err := getActualManifestUrl(
+		result, err := adapter.newManifestRequest(
 			&v1alpha1.PackageInfo{Status: v1alpha1.PackageInfoStatus{ResolvedUrl: "http://localhost/packages/foo/package.yaml"}},
 			"./manifest.yaml",
 		)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(result).To(Equal("http://localhost/packages/foo/manifest.yaml"))
+		Expect(result.URL.String()).To(Equal("http://localhost/packages/foo/manifest.yaml"))
 	})
 	It("should handle plain file name", func() {
-		result, err := getActualManifestUrl(
+		result, err := adapter.newManifestRequest(
 			&v1alpha1.PackageInfo{Status: v1alpha1.PackageInfoStatus{ResolvedUrl: "http://localhost/packages/foo/package.yaml"}},
 			"manifest.yaml",
 		)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(result).To(Equal("http://localhost/packages/foo/manifest.yaml"))
+		Expect(result.URL.String()).To(Equal("http://localhost/packages/foo/manifest.yaml"))
 	})
 	It("should handle relative url with \"..\"", func() {
-		result, err := getActualManifestUrl(
+		result, err := adapter.newManifestRequest(
 			&v1alpha1.PackageInfo{Status: v1alpha1.PackageInfoStatus{ResolvedUrl: "http://localhost/packages/foo/package.yaml"}},
 			"../manifest.yaml",
 		)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(result).To(Equal("http://localhost/packages/manifest.yaml"))
+		Expect(result.URL.String()).To(Equal("http://localhost/packages/manifest.yaml"))
 	})
 	It("should handle absolute path", func() {
-		result, err := getActualManifestUrl(
+		result, err := adapter.newManifestRequest(
 			&v1alpha1.PackageInfo{Status: v1alpha1.PackageInfoStatus{ResolvedUrl: "http://localhost/packages/foo/package.yaml"}},
 			"/manifest.yaml",
 		)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(result).To(Equal("http://localhost/manifest.yaml"))
+		Expect(result.URL.String()).To(Equal("http://localhost/manifest.yaml"))
 	})
 	It("should handle real url", func() {
-		result, err := getActualManifestUrl(
+		result, err := adapter.newManifestRequest(
 			&v1alpha1.PackageInfo{Status: v1alpha1.PackageInfoStatus{ResolvedUrl: "http://localhost/packages/foo/package.yaml"}},
 			"https://github.com/glasskube/glasskube/manifest.yaml",
 		)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(result).To(Equal("https://github.com/glasskube/glasskube/manifest.yaml"))
+		Expect(result.URL.String()).To(Equal("https://github.com/glasskube/glasskube/manifest.yaml"))
+	})
+
+	Context("with basic auth", func() {
+		BeforeEach(func() {
+			adapter.repo = fake.ClientsetWithClient(fake.EmptyClientWithAuth(auth.Basic("test", "test")))
+		})
+
+		It("should add auth header for relative url", func() {
+			result, err := adapter.newManifestRequest(
+				&v1alpha1.PackageInfo{Status: v1alpha1.PackageInfoStatus{ResolvedUrl: "http://localhost/packages/foo/package.yaml"}},
+				"manifest.yaml",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.URL.String()).To(Equal("http://localhost/packages/foo/manifest.yaml"))
+			user, pass, ok := result.BasicAuth()
+			Expect(ok).To(BeTrueBecause("basic auth should be added for relative urls"))
+			Expect(user).To(Equal("test"))
+			Expect(pass).To(Equal("test"))
+		})
+
+		It("should NOT add auth header for absolute url", func() {
+			result, err := adapter.newManifestRequest(
+				&v1alpha1.PackageInfo{Status: v1alpha1.PackageInfoStatus{ResolvedUrl: "http://localhost/packages/foo/package.yaml"}},
+				"https://github.com/glasskube/glasskube/manifest.yaml",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.URL.String()).To(Equal("https://github.com/glasskube/glasskube/manifest.yaml"))
+			user, pass, ok := result.BasicAuth()
+			Expect(ok).To(BeFalseBecause("basic auth must NOT be added for absolute urls"))
+			Expect(user).To(Equal(""))
+			Expect(pass).To(Equal(""))
+		})
 	})
 })

--- a/internal/repo/client/auth/basic.go
+++ b/internal/repo/client/auth/basic.go
@@ -1,0 +1,14 @@
+package auth
+
+import (
+	"net/http"
+)
+
+type basicAuthenticator struct {
+	username, password string
+}
+
+// Authenticate implements client.Authenticator.
+func (b *basicAuthenticator) Authenticate(request *http.Request) {
+	request.SetBasicAuth(b.username, b.password)
+}

--- a/internal/repo/client/auth/bearer.go
+++ b/internal/repo/client/auth/bearer.go
@@ -1,0 +1,14 @@
+package auth
+
+import (
+	"net/http"
+)
+
+type bearerAuthenticator struct {
+	token string
+}
+
+// Authenticate implements client.Authenticator.
+func (b *bearerAuthenticator) Authenticate(request *http.Request) {
+	request.Header.Set("Authorization", "Bearer "+b.token)
+}

--- a/internal/repo/client/auth/interface.go
+++ b/internal/repo/client/auth/interface.go
@@ -1,0 +1,19 @@
+package auth
+
+import "net/http"
+
+type Authenticator interface {
+	Authenticate(request *http.Request)
+}
+
+func Basic(username, password string) Authenticator {
+	return &basicAuthenticator{username: username, password: password}
+}
+
+func Bearer(token string) Authenticator {
+	return &bearerAuthenticator{token: token}
+}
+
+func Noop() Authenticator {
+	return NoopAuthenticator{}
+}

--- a/internal/repo/client/auth/noop.go
+++ b/internal/repo/client/auth/noop.go
@@ -1,0 +1,11 @@
+package auth
+
+import (
+	"net/http"
+)
+
+type NoopAuthenticator struct{}
+
+// Authenticate implements client.Authenticator.
+func (n NoopAuthenticator) Authenticate(request *http.Request) {
+}

--- a/internal/repo/client/clientset.go
+++ b/internal/repo/client/clientset.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"net/http"
 	"reflect"
 	"sync"
 	"time"
@@ -13,6 +12,7 @@ import (
 	"github.com/glasskube/glasskube/api/v1alpha1"
 	"github.com/glasskube/glasskube/internal/adapter"
 	"github.com/glasskube/glasskube/internal/controller/ctrlpkg"
+	"github.com/glasskube/glasskube/internal/repo/client/auth"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -75,7 +75,7 @@ func (d *defaultClientset) ForRepoWithName(name string) RepoClient {
 	}
 	if len(name) > 0 {
 		if repo, err := d.client.GetPackageRepository(context.TODO(), name); err != nil {
-			return &errorclient{err}
+			return &errorclient{err: err}
 		} else {
 			return d.ForRepo(*repo)
 		}
@@ -87,14 +87,14 @@ func (d *defaultClientset) ForRepoWithName(name string) RepoClient {
 // Default implements RepoClientset.
 func (d *defaultClientset) Default() RepoClient {
 	if repos, err := d.client.ListPackageRepositories(context.TODO()); err != nil {
-		return &errorclient{err}
+		return &errorclient{err: err}
 	} else {
 		for _, repo := range repos.Items {
 			if repo.IsDefaultRepository() {
 				return d.ForRepo(repo)
 			}
 		}
-		return &errorclient{errors.New("default repository not found")}
+		return &errorclient{err: errors.New("default repository not found")}
 	}
 }
 
@@ -106,10 +106,10 @@ func (d *defaultClientset) ForRepo(repo v1alpha1.PackageRepository) RepoClient {
 		clientState.lastCheckedRepoSpec = time.Now()
 		return clientState.client
 	} else {
-		if headers, err := d.getAuthHeaders(repo); err != nil {
-			return &errorclient{fmt.Errorf("invalid auth config: %w", err)}
+		if auth, err := d.newAuthenticator(repo); err != nil {
+			return &errorclient{err: fmt.Errorf("invalid auth config: %w", err)}
 		} else {
-			client := New(repo.Spec.Url, headers, d.maxCacheAge)
+			client := New(repo.Spec.Url, auth, d.maxCacheAge)
 			d.clients[repo.Name] = repoClientWithState{
 				client:              client,
 				lastCheckedRepoSpec: time.Now(),
@@ -120,8 +120,7 @@ func (d *defaultClientset) ForRepo(repo v1alpha1.PackageRepository) RepoClient {
 	}
 }
 
-func (d *defaultClientset) getAuthHeaders(repo v1alpha1.PackageRepository) (http.Header, error) {
-	headers := http.Header{}
+func (d *defaultClientset) newAuthenticator(repo v1alpha1.PackageRepository) (auth.Authenticator, error) {
 	if repo.Spec.Auth != nil {
 		if repo.Spec.Auth.Basic != nil {
 			var user, pass string
@@ -159,9 +158,7 @@ func (d *defaultClientset) getAuthHeaders(repo v1alpha1.PackageRepository) (http
 					}
 				}
 			}
-			userpass := fmt.Sprintf("%v:%v", user, pass)
-			userpassEncoded := base64.StdEncoding.EncodeToString([]byte(userpass))
-			headers.Set("Authorization", fmt.Sprintf("Basic %v", userpassEncoded))
+			return auth.Basic(user, pass), nil
 		} else if repo.Spec.Auth.Bearer != nil {
 			var token string
 			if repo.Spec.Auth.Bearer.Token != nil {
@@ -176,10 +173,10 @@ func (d *defaultClientset) getAuthHeaders(repo v1alpha1.PackageRepository) (http
 					token = t
 				}
 			}
-			headers.Set("Authorization", fmt.Sprintf("Bearer %v", token))
+			return auth.Bearer(token), nil
 		}
 	}
-	return headers, nil
+	return auth.Noop(), nil
 }
 
 // Meta implements RepoClientset.

--- a/internal/repo/client/errorclient.go
+++ b/internal/repo/client/errorclient.go
@@ -2,12 +2,14 @@ package client
 
 import (
 	"github.com/glasskube/glasskube/api/v1alpha1"
+	"github.com/glasskube/glasskube/internal/repo/client/auth"
 	"github.com/glasskube/glasskube/internal/repo/types"
 )
 
 // errorclient is a no-op implementation of RepoClient that defers returning an error to the method call.
 // This is done to improve ergonomics of the RepoClientset, such that the ForRepo function does not return an error.
 type errorclient struct {
+	auth.NoopAuthenticator
 	err error
 }
 

--- a/internal/repo/client/repoclient.go
+++ b/internal/repo/client/repoclient.go
@@ -3,6 +3,7 @@ package client
 import (
 	packagesv1alpha1 "github.com/glasskube/glasskube/api/v1alpha1"
 	"github.com/glasskube/glasskube/internal/controller/ctrlpkg"
+	"github.com/glasskube/glasskube/internal/repo/client/auth"
 	"github.com/glasskube/glasskube/internal/repo/types"
 )
 
@@ -11,6 +12,7 @@ type LatestVersionGetter interface {
 }
 
 type RepoClient interface {
+	auth.Authenticator
 	LatestVersionGetter
 	FetchPackageRepoIndex(target *types.PackageRepoIndex) error
 	FetchLatestPackageManifest(name string, target *packagesv1alpha1.PackageManifest) (version string, err error)

--- a/internal/webhook/package_validator_test.go
+++ b/internal/webhook/package_validator_test.go
@@ -20,10 +20,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-var fakeRepoClient = fakerepo.FakeClient{
-	PackageRepositories: []v1alpha1.PackageRepository{{}},
-}
-var fakeRepoClientset = fakerepo.FakeClientset{Client: &fakeRepoClient}
+var fakeRepoClient = fakerepo.EmptyClient()
+var fakeRepoClientset = fakerepo.ClientsetWithClient(fakeRepoClient)
 
 func newPackageValidatingWebhook(objects ...client.Object) *PackageValidatingWebhook {
 	fakeClient := fake.NewClientBuilder().
@@ -36,9 +34,9 @@ func newPackageValidatingWebhook(objects ...client.Object) *PackageValidatingWeb
 		OwnerManager: ownerManager,
 		DependendcyManager: dependency.NewDependencyManager(
 			ctrladapter.NewPackageClientAdapter(fakeClient),
-			&fakeRepoClientset,
+			fakeRepoClientset,
 		),
-		RepoClient: &fakeRepoClientset,
+		RepoClient: fakeRepoClientset,
 	}
 }
 

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -132,7 +132,7 @@ func (c *BootstrapClient) Bootstrap(
 	}
 
 	statusMessage("Fetching Glasskube manifest from "+parsedUrl.Redacted(), true, options.NoProgress)
-	manifests, err := clientutils.FetchResources(options.Url)
+	manifests, err := clientutils.FetchResourcesFromUrl(options.Url)
 	if err != nil {
 		statusMessage("Couldn't fetch Glasskube manifests", false, false)
 		telemetry.BootstrapFailure(time.Since(start))

--- a/pkg/purge/purge.go
+++ b/pkg/purge/purge.go
@@ -70,7 +70,7 @@ func (c *Purger) Purge(ctx context.Context) error {
 		operatorVersion, "slim")
 
 	c.status.SetStatus("Fetching Glasskube manifest from " + manifestUrl)
-	manifests, err := clientutils.FetchResources(manifestUrl)
+	manifests, err := clientutils.FetchResourcesFromUrl(manifestUrl)
 	if err != nil {
 		return fmt.Errorf("Couldn't fetch Glasskube manifests: %w", err)
 	}


### PR DESCRIPTION
## 📑 Description
In this PR I refactored the repoclient to expose the repositories authentication mechanism. 

This is required to enable authenticated requests in the plain manifest adapter. authentication is only added for relative URLs.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information

This came up when testing the trieve GPU package.
