### PR TITLE
feat(package-operator): add "well-known" label field specs

### DIFF
--- a/internal/manifest/plain/prefix.go
+++ b/internal/manifest/plain/prefix.go
@@ -11,7 +11,17 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	kstypes "sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/kyaml/resid"
 )
+
+var wellKnownLabelFieldSpecs = kstypes.FsSlice{
+	// Reference: https://www.keycloak.org/operator/advanced-configuration#_pod_template
+	{
+		Gvk:                resid.Gvk{Group: "k8s.keycloak.org", Version: "v2alpha1", Kind: "Keycloak"},
+		Path:               "/spec/unsupported/podTemplate/metadata/labels",
+		CreateIfNotPresent: true,
+	},
+}
 
 func prefixAndUpdateReferences(
 	pkg ctrlpkg.Package,
@@ -45,6 +55,7 @@ func createKustomization(pkg ctrlpkg.Package) kstypes.Kustomization {
 					v1alpha1.LabelPackageName:         pkg.GetSpec().PackageInfo.Name,
 					v1alpha1.LabelPackageInstanceName: pkg.GetName(),
 				},
+				FieldSpecs:       wellKnownLabelFieldSpecs,
 				IncludeSelectors: true,
 				IncludeTemplates: true,
 			},


### PR DESCRIPTION
## 📑 Description
Some packages contain CRDs where another operator manages some dependent resources. In some cases it can be necessary to refer to those resources by use of a label selector. If supported by a CRD, it would make sense to add the package operator labels to those resources, but for that the package operator needs to know about those fields. 

This PR introduces a list of "well-known" label field specs. Those are field specs of label maps in some widely used CRDs. Currently there is only one well-known label field spec, namely in the Keycloak CRD provided by the keycloak-operator-crds package.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->