### PR TITLE
fix(ui): package detail header breaks when rendering

### DIFF
--- a/internal/web/packagedetail.go
+++ b/internal/web/packagedetail.go
@@ -255,7 +255,7 @@ func (s *server) renderPackageDetailPage(ctx context.Context, r *http.Request, w
 	}
 
 	if headerOnly {
-		repoErr = s.templates.pkgDetailHeaderTmpl.Execute(w, templateData)
+		repoErr = s.templates.pkgDetailHeaderTmpl.Execute(w, s.enrichPage(r, templateData, repoErr))
 		webutil.CheckTmplError(repoErr, fmt.Sprintf("package-detail-header (%s)", p.request.manifestName))
 	} else {
 		repoErr = s.templates.pkgPageTmpl.Execute(w, s.enrichPage(r, templateData, repoErr))


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->

## 📑 Description
`.GitopsMode` template variable was missing when `component=header` was requested, and therefore the `ForPkgDetailHeader` function could not parse it to a bool 

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->