### PR TITLE
docs(website): fix typo's in helm guide

### DIFF
--- a/website/blog/2024-10-11-helm-guide/index.mdx
+++ b/website/blog/2024-10-11-helm-guide/index.mdx
@@ -78,7 +78,7 @@ mychart/
     NOTES.txt         # Optional: Usage notes displayed after installation
 ```
 
-### **Key Components of a Helm Chart:**
+### Key Components of a Helm Chart:
 
 1.  **Templates**:
     -   Template files define the Kubernetes resources required for your application, such as Deployments, Services, ConfigMaps, and more.  
@@ -96,7 +96,7 @@ mychart/
     -   An optional file that defines a schema for validating the structure and types of values provided in `values.yaml` or during installation.
         
 
-### Dendencies in Helm Charts
+### Dependencies in Helm Charts
 
 Chart dependencies allow the user to define relationships between different charts. A chart can specify dependencies on other charts in its `Chart.yaml` file, listing them under the dependencies section.
 


### PR DESCRIPTION
Found a couple of typos that needed fixing in the helm guide. 

## 📑 Description
<!-- Add a brief description of the pr -->

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->