### PR TITLE
fix: plain-text AutoLink display and enably markdown linkify

### DIFF
--- a/cmd/glasskube/cmd/describe.go
+++ b/cmd/glasskube/cmd/describe.go
@@ -25,6 +25,7 @@ import (
 	"github.com/glasskube/glasskube/pkg/describe"
 	"github.com/spf13/cobra"
 	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/extension"
 	"github.com/yuin/goldmark/renderer"
 	goldmarkutil "github.com/yuin/goldmark/util"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -327,6 +328,9 @@ func printValueConfigurations(w io.Writer, values map[string]v1alpha1.ValueConfi
 
 func printMarkdown(w io.Writer, text string) {
 	md := goldmark.New(
+		goldmark.WithExtensions(
+			extension.Linkify,
+		),
 		goldmark.WithRenderer(renderer.NewRenderer(
 			renderer.WithNodeRenderers(
 				goldmarkutil.Prioritized(cliutils.MarkdownRenderer(), 1000),

--- a/internal/cliutils/markdown.go
+++ b/internal/cliutils/markdown.go
@@ -190,11 +190,12 @@ func (*markdownRenderer) renderThematicBreak(
 
 func (*markdownRenderer) renderAutoLink(
 	writer util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
-	if _, err := fmt.Fprint(writer, n.Text(source)); err != nil {
-		return ast.WalkStop, err
-	}
+	al := n.(*ast.AutoLink)
 	if entering {
 		underline.SetWriter(writer)
+		if _, err := writer.Write(al.URL(source)); err != nil {
+			return ast.WalkStop, err
+		}
 	} else {
 		underline.UnsetWriter(writer)
 	}

--- a/internal/manifestvalues/cli/configure.go
+++ b/internal/manifestvalues/cli/configure.go
@@ -14,6 +14,7 @@ import (
 	"github.com/glasskube/glasskube/internal/maputils"
 	"github.com/glasskube/glasskube/internal/util"
 	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/extension"
 	"github.com/yuin/goldmark/renderer"
 	goldmarkutil "github.com/yuin/goldmark/util"
 )
@@ -168,6 +169,9 @@ func printHeader(name string, def v1alpha1.ValueDefinition) {
 
 func printMarkdown(w io.Writer, text string) {
 	md := goldmark.New(
+		goldmark.WithExtensions(
+			extension.Linkify,
+		),
 		goldmark.WithRenderer(renderer.NewRenderer(
 			renderer.WithNodeRenderers(
 				goldmarkutil.Prioritized(cliutils.MarkdownRenderer(), 1000),

--- a/internal/web/templates.go
+++ b/internal/web/templates.go
@@ -24,6 +24,7 @@ import (
 	"github.com/glasskube/glasskube/pkg/condition"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/extension"
 	"github.com/yuin/goldmark/parser"
 	"github.com/yuin/goldmark/text"
 	"github.com/yuin/goldmark/util"
@@ -102,6 +103,9 @@ func (t *templates) parseTemplates() {
 			var buf bytes.Buffer
 
 			converter := goldmark.New(
+				goldmark.WithExtensions(
+					extension.Linkify,
+				),
 				goldmark.WithParserOptions(
 					parser.WithASTTransformers(
 						util.Prioritized(&ASTTransformer{}, 1000),


### PR DESCRIPTION
## 📑 Description
This PR fixes a bug in the CLI markdown renderer that caused `AutoLink` nodes to be displayed incorrectly. It also enables the `Linkify` extension across the entire codebase, which turns plain URLs into clickable links (without this, `AutoLink`s are never even created).

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required

## ℹ Additional Information
I uncovered this while investigating a [failed build](https://github.com/glasskube/glasskube/actions/runs/11366149450/job/31615867320) for a dependency upgrade PR: #1344