### PR TITLE
fix: reject build metadata in version constraints

### DIFF
--- a/internal/dependency/graph/graph.go
+++ b/internal/dependency/graph/graph.go
@@ -276,7 +276,7 @@ func (g *DependencyGraph) add(
 
 		var constraint *semver.Constraints
 		if len(dep.Version) > 0 {
-			if c, err := semver.NewConstraint(dep.Version); err != nil {
+			if c, err := isemver.NewConstraint(dep.Version); err != nil {
 				return err
 			} else {
 				constraint = c
@@ -297,7 +297,7 @@ func (g *DependencyGraph) add(
 
 		var constraint *semver.Constraints
 		if len(cmp.Version) > 0 {
-			if c, err := semver.NewConstraint(cmp.Version); err != nil {
+			if c, err := isemver.NewConstraint(cmp.Version); err != nil {
 				return err
 			} else {
 				constraint = c

--- a/internal/dependency/graph/graph_test.go
+++ b/internal/dependency/graph/graph_test.go
@@ -201,16 +201,14 @@ var _ = Describe("DependencyGraph", func() {
 			Expect(v).To(Equal(semver.MustParse("1.1.0+2")))
 		})
 
-		It("should not consider version metadata for constraints", func() {
-			fooManifest := v1alpha1.PackageManifest{Name: foo, Dependencies: []v1alpha1.Dependency{{Name: bar, Version: ">= 1.0.0, < 1.1.1"}}}
-			bazManifest := v1alpha1.PackageManifest{Name: baz, Dependencies: []v1alpha1.Dependency{{Name: bar, Version: "<= 1.1.0+1"}}}
-			Expect(graph.AddCluster(fooManifest, "v1.0.0", true)).NotTo(HaveOccurred())
-			Expect(graph.AddCluster(bazManifest, "v1.0.0", true)).NotTo(HaveOccurred())
-			versions := []*semver.Version{semver.MustParse("1.0.0"), semver.MustParse("1.1.0+1"), semver.MustParse("1.1.0+2"),
-				semver.MustParse("1.1.1"), semver.MustParse("1.2.0"), semver.MustParse("2.0.0")}
-			v, err := graph.Max(bar, "", versions)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(v).To(Equal(semver.MustParse("1.1.0+2"))) // of baz's <= 1.1.0+1 constraint, the metadata +1 is ignored!
+		It("should reject version metadata in constraints", func() {
+			fooManifest := v1alpha1.PackageManifest{Name: foo, Dependencies: []v1alpha1.Dependency{{
+				Name:    bar,
+				Version: "<= 1.1.0+1",
+			}}}
+			Expect(graph.AddCluster(fooManifest, "v1.0.0", true)).To(MatchError(ContainSubstring(
+				"build metadata is not supported in version constraints",
+			)))
 		})
 	})
 

--- a/internal/semver/validate.go
+++ b/internal/semver/validate.go
@@ -1,11 +1,25 @@
 package semver
 
-import "github.com/Masterminds/semver/v3"
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+var constraintBuildMetadataRegex = regexp.MustCompile(`v?[0-9]+(?:\.[0-9]+){0,2}(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*`)
+
+func NewConstraint(constraint string) (*semver.Constraints, error) {
+	if constraintBuildMetadataRegex.MatchString(constraint) {
+		return nil, fmt.Errorf("build metadata is not supported in version constraints: %s", constraint)
+	}
+	return semver.NewConstraint(constraint)
+}
 
 func ValidateConstraint(version, constraint string) error {
 	if parsedVersion, err := semver.NewVersion(version); err != nil {
 		return err
-	} else if parsedConstraint, err := semver.NewConstraint(constraint); err != nil {
+	} else if parsedConstraint, err := NewConstraint(constraint); err != nil {
 		return err
 	} else {
 		return ValidateVersionConstraint(parsedVersion, parsedConstraint)

--- a/internal/semver/validate_test.go
+++ b/internal/semver/validate_test.go
@@ -72,8 +72,11 @@ var _ = Describe("ValidateConstraint", func() {
 		Entry("When a prerelease is the minimum", ">= 1.0.0-alpha.1", "1.0.0+0", true),
 		Entry("When a prerelease is the minimum", ">= 1.0.0-alpha.1", "3.0.0", true),
 		Entry("When a prerelease is the minimum", ">= 1.0.0-alpha.1", "1.0.0-alpha.0", false),
-
-		Entry("When a minimum contains a build number", ">= 1.0.0+3", "1.0.0+3", true),
-		Entry("When a minimum contains a build number", ">= 1.0.0+3", "1.0.0+2", true), // TODO to be fixed with #405
 	)
+
+	It("rejects constraints with build metadata", func() {
+		Expect(ValidateConstraint("1.0.0+2", ">= 1.0.0+3")).To(MatchError(ContainSubstring(
+			"build metadata is not supported in version constraints",
+		)))
+	})
 })


### PR DESCRIPTION
Refs #405, #1276

## Description
Dependency constraints with build metadata are documented as unsupported, but the graph parser still accepted them.

Before this patch, `<= 1.1.0+1` behaved like `<= 1.1.0`, so `1.1.0+2` could still pass. small footgun, kinda sneaky.

## Reproduce
Before the fix, the graph test expected `1.1.0+2` to pass under a `<= 1.1.0+1` constraint:

```sh
go test ./internal/dependency/graph
```

Now dependency and component constraints go through the local semver helper and reject build metadata up front.

## Checks
`go test ./internal/semver ./internal/dependency/graph`

`go test ./...`

No docs update needed, the docs already say build metadata in dependency ranges is unsupported.
