### PR TITLE
docs: wrong Go version in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,7 +147,7 @@ Please avoid rebasing or force-pushing your branch, because this prevents our co
 
 ## Development Guide 👨‍💻
 
-Glasskube is developed using the [Go](https://golang.org/) programming language. The current version of Go being used is [v1.22](https://go.dev/doc/go1.22). It uses go modules for dependency management.
+Glasskube is developed using the [Go](https://golang.org/) programming language. The current version of Go being used is [v1.23](https://go.dev/doc/go1.23). It uses go modules for dependency management.
 
 We use [GNU Make](https://www.gnu.org/software/make/) and do not support other make flavors.
 


### PR DESCRIPTION
## Summary
The CONTRIBUTING.md states the project uses Go v1.22, but go.mod specifies `go 1.23.0`. This means contributors who install Go 1.22 following the guide will run into compatibility issues when building.

## How to reproduce
1. Open `CONTRIBUTING.md` and find the Development Guide section.
2. It reads: "The current version of Go being used is v1.22."
3. Open `go.mod` — the first line after the module declaration reads `go 1.23.0`.

## Test plan
- Confirm `CONTRIBUTING.md` now references v1.23 with a link to https://go.dev/doc/go1.23.
- Cross-check against `go.mod` to ensure they agree.